### PR TITLE
V0.1.2.0 Updates

### DIFF
--- a/OATCommTestConsole/ConsoleOutput.cs
+++ b/OATCommTestConsole/ConsoleOutput.cs
@@ -6,56 +6,91 @@ using System.Threading.Tasks;
 
 namespace OATCommTestConsole
 {
-    public class ConsoleOutput
-    {
-        public static System.ConsoleColor menuColor = ConsoleColor.DarkYellow;
+	public class ConsoleOutput
+	{
+		public static System.ConsoleColor menuColor = ConsoleColor.DarkYellow;
 
-        public static void Info(string message)
-        {
-            Console.ForegroundColor = ConsoleColor.Gray;
-            Console.WriteLine(message);
-            Console.ResetColor();
-        }
+		public static void Info(string message)
+		{
+			Console.ForegroundColor = ConsoleColor.Gray;
+			Console.WriteLine(message);
+			Console.ResetColor();
+		}
 
-        public static void Success(string message)
-        {
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine(message);
-            Console.ResetColor();
-        }
+		public static void Success(string message)
+		{
+			Console.ForegroundColor = ConsoleColor.Green;
+			Console.WriteLine(message);
+			Console.ResetColor();
+		}
 
-        public static void Warning(string message)
-        {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine(message);
-            Console.ResetColor();
-        }
+		public static void Warning(string message)
+		{
+			Console.ForegroundColor = ConsoleColor.Yellow;
+			Console.WriteLine(message);
+			Console.ResetColor();
+		}
 
-        public static void Error(string message)
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine(message);
-            Console.ResetColor();
-        }
+		public static void Error(string message)
+		{
+			Console.ForegroundColor = ConsoleColor.Red;
+			Console.WriteLine(message);
+			Console.ResetColor();
+		}
 
-        public static void Logo()
-        {
-            Console.ForegroundColor = ConsoleColor.White;
-            Console.WriteLine("    ____   ____  _____ ");
-            Console.WriteLine("   / () \\ / () \\|_   _|");
-            Console.WriteLine("   \\____//__/\\__\\ |_|  ");
-            Console.ResetColor();
-        }
+		public static void Logo()
+		{
+			Console.ForegroundColor = ConsoleColor.Cyan;
+			Console.CursorTop = 1; Console.CursorLeft = 35; Console.Write("Settings ");
+			Console.CursorTop = 2; Console.CursorLeft = 35;
+			if (OATCommTestConsole.Program._commHandler != null)
+			{
+				Console.Write(" Device   : " + (OATCommTestConsole.Program._commHandler.Connected ? "Connected (" + OATCommTestConsole.Program._oatFwVersion + " on " + OATCommTestConsole.Program._comPort + ")" : "Disconnected"));
+			}
+			else
+			{
+				Console.Write(" Device   : " + (string.IsNullOrEmpty(OATCommTestConsole.Program._comPort) ? "<unset>" : OATCommTestConsole.Program._comPort));
+			}
+			Console.CursorTop = 3; Console.CursorLeft = 35; Console.Write(" Baudrate : " + OATCommTestConsole.Program._baudRate);
+			Console.CursorTop = 4; Console.CursorLeft = 35; Console.Write(" Timeouts : R:" + OATCommTestConsole.Program._readTimeout + "ms  W:" + OATCommTestConsole.Program._writeTimeout + "ms");
 
-        public static void PreTestInfo()
-        {
-            Console.ForegroundColor = menuColor;
-            Console.WriteLine("****************************** IMPORTANT *****************************\r");
-            Console.WriteLine("* Make sure the device shows up in the Device Manager.               *\r");
-            Console.WriteLine("* Do not change any of the USB device settings in Windows.           *\r");
-            Console.WriteLine("**********************************************************************\r");
+			Console.ResetColor();
+			Console.CursorTop = 0;
+			Console.CursorLeft = 0;
 
-            Console.ResetColor();
-        }
-    }
+			Console.ForegroundColor = ConsoleColor.White;
+			Console.WriteLine(@"    ______    ____  _______ ");
+			Console.WriteLine(@"   /      \  /    \|__   __|");
+			Console.WriteLine(@"   |  ()  | /  ()  \  | |");
+			Console.WriteLine(@"   \______//___/\___\ |_|  ");
+			Console.WriteLine();
+			Console.ResetColor();
+		}
+
+		public static void PreTestInfo()
+		{
+			Console.ForegroundColor = menuColor;
+			Console.WriteLine("****************************** IMPORTANT *****************************\r");
+			Console.WriteLine("* Make sure the device shows up in the Device Manager.               *\r");
+			Console.WriteLine("* Do not change any of the USB device settings in Windows.           *\r");
+			Console.WriteLine("**********************************************************************\r");
+
+			Console.ResetColor();
+		}
+
+		public static void ClearRestOfScreen()
+		{
+			int left = Console.CursorLeft;
+			int top = Console.CursorTop;
+			var clearLine = new String(' ', Console.WindowWidth - 1);
+			for (int i = top; i < Console.WindowHeight - 1; i++)
+			{
+				Console.CursorLeft = 0;
+				Console.CursorTop = i;
+				Console.WriteLine(clearLine);
+			}
+			Console.CursorLeft = left;
+			Console.CursorTop = top;
+		}
+	}
 }

--- a/OATCommTestConsole/Properties/AssemblyInfo.cs
+++ b/OATCommTestConsole/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.1.0")]
+[assembly: AssemblyVersion("0.1.2.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/OATCommTestConsole/README.md
+++ b/OATCommTestConsole/README.md
@@ -32,7 +32,7 @@ Choose one of the following options:
 ```
 
 ```bash
---------------------------------------- SUMMERY -----------------------------------------------------------
+--------------------------------------- SUMMARY -----------------------------------------------------------
 |                   Product name | OpenAstroTracker                                                       |
 |                Firmare version | V1.8.65                                                                |
 |            Mount configuration | Mega,NEMA|16|400,NEMA|16|400,NO_GPS,NO_AZ_ALT,NO_GYRO,NO_LCD,          |

--- a/OATCommTestConsole/SerialCom.cs
+++ b/OATCommTestConsole/SerialCom.cs
@@ -10,7 +10,7 @@ namespace OATCommTestConsole
         private SerialPort _port;
 
         private int _readTimeout = 1000;
-        private int _writeTimeout = 250;
+        private int _writeTimeout = 1000;
         private int _baudRate = 57600;
 
         public SerialCommunicationHandler(string comPort)


### PR DESCRIPTION
- Added status display in logo
- Prevented scrolling in some tests.
- Added status info from 1.8.67.
- Set all timeouts to 1000ms (as latest OATControl does, too)