### PR TITLE
V0.9.9.27 Updates

### DIFF
--- a/OATControl/DlgChooseOat.xaml.cs
+++ b/OATControl/DlgChooseOat.xaml.cs
@@ -426,6 +426,19 @@ namespace OATControl
 						{
 							ShowManualLocation = true;
 							CurrentStep = Steps.ConfirmLocation;
+							// Let's get teh coordinate stored on the OAT
+							var locDoneEvent = new AutoResetEvent(false);
+							bool gotLoc = false;
+							float lat = 0, lng = 0;
+							_sendCommand(":Gt#,#", (a) => { gotLoc = a.Success && TryParseLatLong(a.Data, ref lat); });
+							_sendCommand(":Gg#,#", (a) => { gotLoc = gotLoc && a.Success && TryParseLatLong(a.Data, ref lng); locDoneEvent.Set(); });
+							locDoneEvent.WaitOne();
+							if (gotLoc)
+							{
+								Latitude = lat;
+								Longitude = 180.0f - lng;
+							}
+							break;
 						}
 					}
 					break;

--- a/OATControl/MainWindow.xaml
+++ b/OATControl/MainWindow.xaml
@@ -544,7 +544,6 @@
 			<Button Grid.Row="4" Grid.Column="2" Content="Settings" Margin="0,2" HorizontalAlignment="Right" Padding="15,0" IsEnabled="{Binding MountConnected}" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding ShowSettingsCommand}"/>
 			<Button Grid.Row="5" Grid.Column="2" Content="Log Files" Margin="0,2" HorizontalAlignment="Right" Padding="15,0" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding ShowLogFolderCommand}" />
 
-
 			<Grid Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" >
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="*" />
@@ -554,7 +553,7 @@
 				<TextBlock Grid.Row="0" Grid.Column="1"  Text="Mount" Style="{StaticResource TextBlockHeading}" Margin="0,10,0,0" HorizontalAlignment="Right"/>
 				<Button Grid.Column="2" Margin="10,12,0,0" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding ConnectScopeCommand}" Content="{Binding ConnectCommandString}"/>
 			</Grid>
-			<TextBlock Grid.Row="7" Grid.Column="2" Text="{Binding ScopeName}" Style="{StaticResource TextBlockLabel}" Margin="0,2,0,0" HorizontalAlignment="Right" />
+			<TextBlock Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="3" Text="{Binding ScopeName}" Style="{StaticResource TextBlockLabel}" Margin="0,2,0,0" HorizontalAlignment="Right" />
 		</Grid>
 
 	</Grid>

--- a/OATControl/Properties/AssemblyInfo.cs
+++ b/OATControl/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.9.26")]
+[assembly: AssemblyVersion("0.9.9.27")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/OATControl/SettingsDialog.xaml.cs
+++ b/OATControl/SettingsDialog.xaml.cs
@@ -29,6 +29,16 @@ namespace OATControl
 			dispatchTimer = new DispatcherTimer(TimeSpan.FromMilliseconds(333), DispatcherPriority.Normal, OnTimer, Dispatcher.CurrentDispatcher);
 			_mount = mount;
 			this.DataContext = _mount;
+			if ((_mount.RAStepsPerDegree < 10) || (_mount.DECStepsPerDegree < 10))
+			{
+				MessageBox.Show(
+					"It seems that the steps for RA and DEC have been incorrectly configured. It is strongly suggested to do a Factory Reset on the next screen.",
+					"Invalid EEPROM Data",
+					MessageBoxButton.OK,
+					MessageBoxImage.Exclamation
+				);
+			}
+
 			_mount.RAStepsPerDegreeEdit = _mount.RAStepsPerDegree;
 			_mount.DECStepsPerDegreeEdit = _mount.DECStepsPerDegree;
 			InitializeComponent();

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ To install any of these, click on the latest release under Releases to the right
 
 Change Log:
 ===========
+**V0.9.9.27 - Updates**
+- TCP connections did not correctly shutdown the communications thread on disconnect. This could leave zombie OATcontrol processes on the machine.
+- With no GPS, the lat long was not retrieved from OAT as the default for manual entry. It is now.
+- Detected the incorrect RA/DEC steps in the Settings and pop up a message box suggesting factory reset.
+- Fixed label width at bottom of main UI.
+
+**V0.9.9.26 - Updates**
+- Added label to slew rate boxes.
+- Added log folder link to main UI.
+- Added log file flushing in case of crash.
+
 **V0.9.9.25 - Updates**
 - Added Slewrate controls to Mini controller, bound to 1, 2, 3, and 4 keys.
 


### PR DESCRIPTION
- TCP connections did not correctly shutdown the communications thread on disconnect. This could leave zombie OATcontrol processes on the machine.
- With no GPS, the lat long was not retrieved from OAT as the default for manual entry. It is now.
- Detected the incorrect RA/DEC steps in the Settings and pop up a message box suggesting factory reset.
- Fixed label width at bottom of main UI.