### PR TITLE
V0.9.9.28 Updates

### DIFF
--- a/OATCommunications.WPF/CommunicationHandlers/SerialCommunicationHandler.cs
+++ b/OATCommunications.WPF/CommunicationHandlers/SerialCommunicationHandler.cs
@@ -121,6 +121,7 @@ namespace OATCommunications.WPF.CommunicationHandlers
 					}
 				}
 				while (attempts < 10);
+				return false;
 			}
 			return true;
 		}

--- a/OATCommunications/TelescopeCommandHandlers/OatmealTelescopeCommandHandlers.cs
+++ b/OATCommunications/TelescopeCommandHandlers/OatmealTelescopeCommandHandlers.cs
@@ -7,6 +7,7 @@ using Microsoft.Win32.SafeHandles;
 using OATCommunications.CommunicationHandlers;
 using OATCommunications.Model;
 using OATCommunications.TelescopeCommandHandlers;
+using OATCommunications.Utilities;
 
 namespace OATCommunications
 {
@@ -188,21 +189,39 @@ namespace OATCommunications
 
 		private bool TryParseRA(string ra, out double dRa)
 		{
-			var parts = ra.Split(':');
-			dRa = int.Parse(parts[0]) + int.Parse(parts[1]) / 60.0 + int.Parse(parts[2]) / 3600.0;
-			return true;
+			try
+			{
+				var parts = ra.Split(':');
+				dRa = int.Parse(parts[0]) + int.Parse(parts[1]) / 60.0 + int.Parse(parts[2]) / 3600.0;
+				return true;
+			}
+			catch (Exception ex)
+			{
+				Log.WriteLine("OAT: Can't parse RA from {0}", ra);
+			}
+			dRa = 0;
+			return false;
 		}
 
 		private bool TryParseDec(string dec, out double dDec)
 		{
-			var parts = dec.Split('*', '\'');
-			dDec = int.Parse(parts[0]) + int.Parse(parts[1]) / 60.0;
-			if (parts.Length > 2)
+			try
 			{
-				dDec += int.Parse(parts[2]) / 3600.0;
-			}
+				var parts = dec.Split('*', '\'');
+				dDec = int.Parse(parts[0]) + int.Parse(parts[1]) / 60.0;
+				if (parts.Length > 2)
+				{
+					dDec += int.Parse(parts[2]) / 3600.0;
+				}
 
-			return true;
+				return true;
+			}
+			catch (Exception ex)
+			{
+				Log.WriteLine("OAT: Can't parse DEC from {0}", dec);
+			}
+			dDec = 0;
+			return false;
 		}
 
 		public async Task<bool> StartMoving(string dir)

--- a/OATControl/DlgChooseOat.xaml
+++ b/OATControl/DlgChooseOat.xaml
@@ -53,6 +53,7 @@
 				 HorizontalAlignment="Stretch" 
 				 MinWidth="20" 
 				 Background="Transparent" 
+				 MouseDoubleClick="Device_MouseDoubleClick"
 				 Margin="0,12,100,0">
 			<ListBox.ItemTemplate>
 				<DataTemplate DataType="string">

--- a/OATControl/DlgChooseOat.xaml.cs
+++ b/OATControl/DlgChooseOat.xaml.cs
@@ -589,5 +589,10 @@ namespace OATControl
 			}
 		}
 
+		private void Device_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+		{
+			CurrentStep = Steps.WaitForConnect;
+			AdvanceStateMachine();
+		}
 	}
 }

--- a/OATControl/MainWindow.xaml
+++ b/OATControl/MainWindow.xaml
@@ -529,6 +529,15 @@
 
 			<TextBlock Grid.Column="0" Grid.Row="1" Text="Tracking" Margin="0,5,0,1"  Style="{StaticResource TextBlockHeading}" />
 			<Controls:ToggleSwitchButton  Grid.Column="1" Grid.Row="1"  Margin="0,6,0,0" VerticalAlignment="Center" IsEnabled="{Binding MountConnected}" IsChecked="{Binding IsTracking}"/>
+			<Grid Grid.Row="1" Grid.Column="2" Visibility="{Binding MountConnected, Converter={StaticResource bool2VisibilityConverter}}">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="Auto" />
+				</Grid.ColumnDefinitions>
+				<TextBlock Grid.Column="0" Text="Connected" Style="{StaticResource TextBlockLabelSmall}"/>
+				<TextBlock Grid.Column="1" MinWidth="64" Text="{Binding ConnectedTime}"  Style="{StaticResource TextBlockLabelValue}" TextAlignment="Center" Padding="5,2"/>
+
+			</Grid>
 
 			<Grid Grid.Row="2" Grid.Column="1" >
 				<Grid.ColumnDefinitions>

--- a/OATControl/Properties/AssemblyInfo.cs
+++ b/OATControl/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.9.27")]
+[assembly: AssemblyVersion("0.9.9.28")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ To install any of these, click on the latest release under Releases to the right
 
 Change Log:
 ===========
+**V0.9.9.28 - Updates**
+- Sometimes reconnects would fail and crash OATControl. Now they don't crash it.
+- Added a connection time display.
+- Serial communciation would report successful connection even though it wasn't.
+- Made double-click on device proceed to next step in connection dialog.
+
 **V0.9.9.27 - Updates**
 - TCP connections did not correctly shutdown the communications thread on disconnect. This could leave zombie OATcontrol processes on the machine.
 - With no GPS, the lat long was not retrieved from OAT as the default for manual entry. It is now.


### PR DESCRIPTION
- Sometimes reconnects would fail and crash OATControl. Now they don't crash it.
- Added a connection time display.
- Serial communciation would report successful connection even though it wasn't.
- Made double-click on device proceed to next step in connection dialog.