### PR TITLE
V6.5.3.0 Updates

### DIFF
--- a/ASCOM.Driver/OpenAstroTracker/Models.cs
+++ b/ASCOM.Driver/OpenAstroTracker/Models.cs
@@ -8,6 +8,7 @@ namespace ASCOM.OpenAstroTracker
     public class ProfileData {
         public bool TraceState;
         public string ComPort;
+        public long BaudRate;
         public double Latitude;
         public double Longitude;
         public double Elevation; 

--- a/ASCOM.Driver/OpenAstroTracker/OpenAstroTracker.csproj
+++ b/ASCOM.Driver/OpenAstroTracker/OpenAstroTracker.csproj
@@ -119,6 +119,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="ASCOM.png" />
+    <None Include="README.txt" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/ASCOM.Driver/OpenAstroTracker/Properties/AssemblyInfo.cs
+++ b/ASCOM.Driver/OpenAstroTracker/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("0.3.1.0")]
-[assembly: AssemblyFileVersion("0.3.1.0")]
+[assembly: AssemblyVersion("6.5.3.0")]
+[assembly: AssemblyFileVersion("6.5.3.0")]
 
 [assembly: ComVisibleAttribute(false)]

--- a/ASCOM.Driver/OpenAstroTracker/README.txt
+++ b/ASCOM.Driver/OpenAstroTracker/README.txt
@@ -2,25 +2,28 @@
 OpenAstroTracker ASCOM Driver 
 =============================
 
-Version 0.3.1.0, published 20 March 2021
+Version 6.5.3.0, published 10 April 2021
 ----------------------------------------
 
 * History
-	* 0.1.3.0	2020-04-15		:		Initial release
-	* 0.1.3.1	2020-04-16		:		BUGFIX : Allow , as decimal separator where Windows regional settings use it.
+	* 6.5.3.0	2021-04-19		:		CHANGE : Fixed Sync command. Added choosable baudrate. Lots of bug fixes.
+	* 0.3.1.0	2021-03-20		:		CHANGE : Added Rates support and fixed a bug causing an error in MoveAxis.
+	* 0.3.0.0	2020-11-30		:		CHANGE : Added move with slewrate support, stable release
+	* 0.2.0.0b	2020-04-20		:		CHANGE : Local Server version of driver, first release
+	* 0.1.4.2b	2020-04-20		:		CHANGE : Driver uses :CM LX200 Protocol command to sync
+	* 0.1.4.1b	2020-04-18		:		BUGFIX : Driver not correctly handling return value from Halt
 	* 0.1.4b	2020-04-18		:		CHANGE : Implement pulse guiding.
 										BUGFIX : Uninstaller was not correctly removing previous driver DLL
-	* 0.1.4.1b	2020-04-18		:		BUGFIX : Driver not correctly handling return value from Halt
-	* 0.1.4.2b	2020-04-20		:		CHANGE : Driver uses :CM LX200 Protocol command to sync
-	* 0.2.0.0b	2020-04-20		:		CHANGE : Local Server version of driver, first release
-	* 0.3.0.0	2020-11-30		:		CHANGE : Added move with slewrate support, stable release
-	* 0.3.1.0	2021-03-20		:		CHANGE : Added Rates support and fixed a bug causing an error in MoveAxis.
-										
+	* 0.1.3.1	2020-04-16		:		BUGFIX : Allow , as decimal separator where Windows regional settings use it.
+	* 0.1.3.0	2020-04-15		:		Initial release
+
+
 * Arduino information
-	* Tested on Arduino Mega and ESP32.  No other variants of Arduino have been tested, or are officially supported.
-	* Currently built for Version V1.6.32 and above of the Arduino Code (As of 2020-04-23)
-	
-* Last Conformance Test - 2020-04-13
+	* Tested on Arduino Mega and ESP32.  No other variants of Arduino have been tested, or are officially supported (MKS falls under Mega).
+	* Tested with V1.9.03 firmware, which is the RECOMMENDED version.
+	* Will probably work with earlier version (down to V1.6.32 and later).
+
+* Last Conformance Test - 2021-04-09 - All tests passed, no errors, no issues.
 
 * Cautions and warnings
 	* CAUTION : Neither the mount nor the driver currently support setting any slew limits.  Thus it is quite possible 
@@ -29,9 +32,7 @@ Version 0.3.1.0, published 20 March 2021
 				So...keep track of your own towel.
 
 * Known Issues
-	* All known current issues are probably documented at https://github.com/OpenAstroTech/OpenAstroTracker-Desktop
-	
+	* All known current issues are tracked on the Discord server.
+
 * Work in Progress / Coming soon
 	* Ability to set home position of mount via ASCOM
-
-	

--- a/ASCOM.Driver/OpenAstroTracker/SharedResources.cs
+++ b/ASCOM.Driver/OpenAstroTracker/SharedResources.cs
@@ -20,272 +20,341 @@ using System.Threading;
 using ASCOM.Utilities;
 
 
-namespace ASCOM.OpenAstroTracker {
-    /// <summary>
-    /// The resources shared by all drivers and devices, in this example it's a serial port with a shared SendMessage method
-    /// an idea for locking the message and handling connecting is given.
-    /// In reality extensive changes will probably be needed.
-    /// Multiple drivers means that several applications connect to the same hardware device, aka a hub.
-    /// Multiple devices means that there are more than one instance of the hardware, such as two focusers.
-    /// In this case there needs to be multiple instances of the hardware connector, each with it's own connection count.
-    /// </summary>
-    public static class SharedResources {
-        // object used for locking to prevent multiple drivers accessing common code at the same time
-        private static readonly object lockObject = new object();
-        private static TraceLogger traceLogger;
-        private static Profile driverProfile;
-        public static string driverID = "ASCOM.OpenAstroTracker.Telescope";
+namespace ASCOM.OpenAstroTracker
+{
+	/// <summary>
+	/// The resources shared by all drivers and devices, in this example it's a serial port with a shared SendMessage method
+	/// an idea for locking the message and handling connecting is given.
+	/// In reality extensive changes will probably be needed.
+	/// Multiple drivers means that several applications connect to the same hardware device, aka a hub.
+	/// Multiple devices means that there are more than one instance of the hardware, such as two focusers.
+	/// In this case there needs to be multiple instances of the hardware connector, each with it's own connection count.
+	/// </summary>
+	public static class SharedResources
+	{
+		// object used for locking to prevent multiple drivers accessing common code at the same time
+		private static readonly object lockObject = new object();
+		private static TraceLogger traceLogger;
+		private static Profile driverProfile;
+		public static string driverID = "ASCOM.OpenAstroTracker.Telescope";
 
-        private static string comPortProfileName = "COM Port";
-        private static string traceStateProfileName = "Trace Level";
-        private static string latitudeProfileName = "Latitude";
-        private static string longitudeProfileName = "Longitude";
-        private static string elevationProfileName = "Elevation";
+		private static string comPortProfileName = "COM Port";
+		private static string baudRateProfileName = "Baud Rate";
+		private static string traceStateProfileName = "Trace Level";
+		private static string latitudeProfileName = "Latitude";
+		private static string longitudeProfileName = "Longitude";
+		private static string elevationProfileName = "Elevation";
 
-        private static string comPortDefault = "COM5";
-        private static string traceStateDefault = "True";
-        private static double latitudeDefault = 30;
-        private static double longitudeDefault = -97;
-        private static double elevationDefault = 1;
+		private static string comPortDefault = "COM5";
+		private static string baudRateDefault = "28800";
+		private static string traceStateDefault = "True";
+		private static double latitudeDefault = 30;
+		private static double longitudeDefault = -97;
+		private static double elevationDefault = 1;
 
-        //
-        // Public access to shared resources
-        //
+		//
+		// Public access to shared resources
+		//
 
-        public static TraceLogger tl {
-            get {
-                if (traceLogger == null) {
-                    traceLogger = new TraceLogger("", "OpenAstroTracker.LocalServer");
-                    traceLogger.Enabled = true;
-                }
+		public static TraceLogger tl
+		{
+			get
+			{
+				if (traceLogger == null)
+				{
+					traceLogger = new TraceLogger("", "OpenAstroTracker.LocalServer");
+					traceLogger.Enabled = true;
+				}
 
-                return traceLogger;
-            }
-        }
+				return traceLogger;
+			}
+		}
 
-        public static ProfileData ReadProfile() {
-            using (Profile driverProfile = new Profile()) {
-                driverProfile.DeviceType = "Telescope";
-                return new ProfileData {
-                    TraceState = Convert.ToBoolean(driverProfile.GetValue(driverID, traceStateProfileName, String.Empty,
-                        traceStateDefault)),
-                    ComPort = driverProfile.GetValue(driverID, comPortProfileName, string.Empty, comPortDefault),
-                    Latitude = Convert.ToDouble(driverProfile.GetValue(driverID, latitudeProfileName, string.Empty,
-                        latitudeDefault.ToString())),
-                    Longitude = Convert.ToDouble(driverProfile.GetValue(driverID, longitudeProfileName, string.Empty,
-                        longitudeDefault.ToString())),
-                    Elevation = Convert.ToDouble(driverProfile.GetValue(driverID, elevationProfileName, string.Empty,
-                        elevationDefault.ToString()))
-                };
-            }
-        }
+		public static ProfileData ReadProfile()
+		{
+			using (Profile driverProfile = new Profile())
+			{
+				driverProfile.DeviceType = "Telescope";
+				return new ProfileData
+				{
+					TraceState = Convert.ToBoolean(driverProfile.GetValue(driverID, traceStateProfileName, String.Empty, traceStateDefault)),
+					ComPort = driverProfile.GetValue(driverID, comPortProfileName, string.Empty, comPortDefault),
+					BaudRate = long.Parse(driverProfile.GetValue(driverID, baudRateProfileName, string.Empty, baudRateDefault)),
+					Latitude = Convert.ToDouble(driverProfile.GetValue(driverID, latitudeProfileName, string.Empty, latitudeDefault.ToString())),
+					Longitude = Convert.ToDouble(driverProfile.GetValue(driverID, longitudeProfileName, string.Empty, longitudeDefault.ToString())),
+					Elevation = Convert.ToDouble(driverProfile.GetValue(driverID, elevationProfileName, string.Empty, elevationDefault.ToString()))
+				};
+			}
+		}
 
-        public static void WriteProfile(ProfileData profile) {
-            using (Profile driverProfile = new Profile()) {
-                driverProfile.DeviceType = "Telescope";
-                driverProfile.WriteValue(driverID, traceStateProfileName, profile.TraceState.ToString());
-                driverProfile.WriteValue(driverID, comPortProfileName, profile.ComPort.ToString());
-                driverProfile.WriteValue(driverID, latitudeProfileName, profile.Latitude.ToString());
-                driverProfile.WriteValue(driverID, longitudeProfileName, profile.Longitude.ToString());
-                driverProfile.WriteValue(driverID, elevationProfileName, profile.Elevation.ToString());
-            }
-        }
+		public static void WriteProfile(ProfileData profile)
+		{
+			using (Profile driverProfile = new Profile())
+			{
+				driverProfile.DeviceType = "Telescope";
+				driverProfile.WriteValue(driverID, traceStateProfileName, profile.TraceState.ToString());
+				driverProfile.WriteValue(driverID, comPortProfileName, profile.ComPort.ToString());
+				driverProfile.WriteValue(driverID, baudRateProfileName, profile.BaudRate.ToString());
+				driverProfile.WriteValue(driverID, latitudeProfileName, profile.Latitude.ToString());
+				driverProfile.WriteValue(driverID, longitudeProfileName, profile.Longitude.ToString());
+				driverProfile.WriteValue(driverID, elevationProfileName, profile.Elevation.ToString());
+			}
+		}
 
-        #region single serial port connector
+		#region single serial port connector
 
-        //
-        // this region shows a way that a single serial port could be connected to by multiple 
-        // drivers.
-        //
-        // Connected is used to handle the connections to the port.
-        //
-        // SendMessage is a way that messages could be sent to the hardware without
-        // conflicts between different drivers.
-        //
-        // All this is for a single connection, multiple connections would need multiple ports
-        // and a way to handle connecting and disconnection from them - see the
-        // multi driver handling section for ideas.
-        //
+		//
+		// this region shows a way that a single serial port could be connected to by multiple 
+		// drivers.
+		//
+		// Connected is used to handle the connections to the port.
+		//
+		// SendMessage is a way that messages could be sent to the hardware without
+		// conflicts between different drivers.
+		//
+		// All this is for a single connection, multiple connections would need multiple ports
+		// and a way to handle connecting and disconnection from them - see the
+		// multi driver handling section for ideas.
+		//
 
-        /// <summary>
-        /// Shared serial port
-        /// </summary>
-        public static Serial SharedSerial { get; } = new ASCOM.Utilities.Serial();
+		/// <summary>
+		/// Shared serial port
+		/// </summary>
+		public static Serial SharedSerial { get; } = new ASCOM.Utilities.Serial();
 
-        /// <summary>
-        /// number of connections to the shared serial port
-        /// </summary>
-        public static int Connections { get; set; } = 0;
+		/// <summary>
+		/// number of connections to the shared serial port
+		/// </summary>
+		public static int Connections { get; set; } = 0;
 
-        /// <summary>
-        /// Example of a shared SendMessage method, the lock
-        /// prevents different drivers tripping over one another.
-        /// It needs error handling and assumes that the message will be sent unchanged
-        /// and that the reply will always be terminated by a "#" character.
-        /// </summary>
-        /// <param name="message"></param>
-        /// <returns></returns>
-        private static string SendMessage(string message, Boolean reply) {
-            lock (lockObject) {
-                tl.LogMessage("OAT Server", "Lock Object");
-                if (!message.EndsWith("#")) {
-                    message += "#";
-                }
+		/// <summary>
+		/// The possible replies that a Meade command can produce
+		/// </summary>
+		enum ExpectedAnswer
+		{
+			None,
+			Digit,
+			HashTerminated
+		}
 
-                if (SharedSerial.Connected && !String.IsNullOrEmpty(message)) {
-                    tl.LogMessage("Telescope", "Send message: " + message);
-                    SharedSerial.ClearBuffers();
-                    SharedSerial.Transmit(message);
-                    if (reply) {
-                        string retVal;
-                        string cmdGroup = message.Substring(1, 1);
-                        switch (cmdGroup) {
-                            case "S":
-                            case "M":
-                            case "h":
-                            case "Q":
-                                retVal = SharedSerial.ReceiveCounted(1);
-                                break;
-                            default:
-                                retVal = SharedSerial.ReceiveTerminated("#");
-                                retVal = retVal.Replace("#", "");
-                                break;
-                        }
+		/// <summary>
+		/// A shared SendMessage method, the lock prevents different drivers tripping over one another.
+		/// The message passed should end in one of these endings:
+		///	 #   - the command does not expect a reply
+		///	 #,n - the command expect a single numerical digit (always 0 or 1)
+		///	 #,# - the command expects a string reply that ends in a #
+		///	 It is very important to send the right variation since otherwise the protocol will become confused.
+		/// </summary>
+		public static string SendMessage(string message)
+		{
+			string retVal = string.Empty;
+			lock (lockObject)
+			{
+				tl.LogMessage("OAT Server", "Locked Serial");
 
-                        return retVal;
-                    }
-                    else return "";
-                }
-                else {
-                    tl.LogMessage("OAT Server", "Not connected or Empty Message: " + message);
-                    return "";
-                }
-            }
-        }
+				ExpectedAnswer expect = ExpectedAnswer.None;
 
-        public static string SendPassThroughCommand(string message, string terminator) {
-            lock (lockObject) {
-                tl.LogMessage("OAT Server", "Lock Object");
+				if (message.EndsWith("#,#"))
+				{
+					message = message.Substring(0, message.Length - 2);
+					expect = ExpectedAnswer.HashTerminated;
+				}
+				else if (message.EndsWith("#,n"))
+				{
+					message = message.Substring(0, message.Length - 2);
+					expect = ExpectedAnswer.Digit;
+				}
+				else if (!message.EndsWith("#"))
+				{
+					message += "#";
+				}
 
-                try {
-                    if (SharedSerial.Connected && !String.IsNullOrEmpty(message)) {
-                        tl.LogMessage("Telescope", "Send message: " + message);
-                        SharedSerial.ClearBuffers();
-                        SharedSerial.Transmit(message);
-                        if (!string.IsNullOrEmpty(terminator)) {
-                            return SharedSerial.ReceiveTerminated(terminator.ToString());
-                        }
-                        return string.Empty;
-                    }
-                    else {
-                        tl.LogMessage("OAT Server", "Not connected or Empty Message: " + message);
-                        return "";
-                    }
-                }
-                catch (Exception e) {
-                    tl.LogMessage($"Caught exception while SendPassThroughCommand - ${message}", e.Message);
-                    return "";
-                }
-                
-            }
-        }
+				if (SharedSerial.Connected && !String.IsNullOrEmpty(message))
+				{
+					tl.LogMessage("OAT Server", "Send message (expected reply : " + expect.ToString() + ") : " + message);
+					SharedSerial.ClearBuffers();
+					SharedSerial.Transmit(message);
+					switch (expect)
+					{
+						case ExpectedAnswer.Digit:
+							tl.LogMessage("OAT Server", "Wait for number reply");
+							retVal = SharedSerial.ReceiveCounted(1);
+							break;
+						case ExpectedAnswer.HashTerminated:
+							tl.LogMessage("OAT Server", "Wait for string reply");
+							retVal = SharedSerial.ReceiveTerminated("#");
+							tl.LogMessage("OAT Server", "Raw reply :" + retVal);
+							retVal = retVal.TrimEnd('#');
+							break;
+					}
+
+					tl.LogMessage("OAT Server", "Reply: " + retVal);
+				}
+				else
+				{
+					tl.LogMessage("OAT Server", "Not connected or Empty Message: " + message);
+				}
+			}
+
+			tl.LogMessage("OAT Server", "Unlocked Serial");
+			return retVal;
+		}
+
+		public static string SendPassThroughCommand(string message, string terminator)
+		{
+			lock (lockObject)
+			{
+				tl.LogMessage("OAT Server", "Locked Serial");
+
+				try
+				{
+					if (SharedSerial.Connected && !String.IsNullOrEmpty(message))
+					{
+						tl.LogMessage("Telescope", "Send message: " + message);
+						SharedSerial.ClearBuffers();
+						SharedSerial.Transmit(message);
+						if (!string.IsNullOrEmpty(terminator))
+						{
+							return SharedSerial.ReceiveTerminated(terminator.ToString());
+						}
+					}
+					else
+					{
+						tl.LogMessage("OAT Server", "Not connected or Empty Message: " + message);
+					}
+				}
+				catch (Exception e)
+				{
+					tl.LogMessage($"Caught exception while SendPassThroughCommand - ${message}", e.Message);
+				}
+			}
+
+			tl.LogMessage("OAT Server", "Unlocked Serial");
+			return string.Empty;
+		}
 
 
-        /// <summary>
-        /// Example of handling connecting to and disconnection from the
-        /// shared serial port.
-        /// Needs error handling
-        /// the port name etc. needs to be set up first, this could be done by the driver
-        /// checking Connected and if it's false setting up the port before setting connected to true.
-        /// It could also be put here.
-        /// </summary>
-        public static bool Connected {
-            set {
-                lock (lockObject) {
-                    if (value) {
-                        if (Connections == 0) {
-                            try {
-                                SharedSerial.DTREnable = false;
-                                SharedSerial.PortName = ReadProfile().ComPort;
-                                SharedSerial.ReceiveTimeoutMs = 2000;
-                                SharedSerial.Speed = ASCOM.Utilities.SerialSpeed.ps57600;
-                                SharedSerial.Connected = true;
+		/// <summary>
+		/// Example of handling connecting to and disconnection from the
+		/// shared serial port.
+		/// Needs error handling
+		/// the port name etc. needs to be set up first, this could be done by the driver
+		/// checking Connected and if it's false setting up the port before setting connected to true.
+		/// It could also be put here.
+		/// </summary>
+		public static bool Connected
+		{
+			set
+			{
+				lock (lockObject)
+				{
+					if (value)
+					{
+						if (Connections == 0)
+						{
+							try
+							{
+								SharedSerial.DTREnable = false;
+								SharedSerial.PortName = ReadProfile().ComPort;
+								SharedSerial.ReceiveTimeoutMs = 2000;
+								SharedSerial.Speed = (SerialSpeed)ReadProfile().BaudRate;
+								SharedSerial.Connected = true;
 
-                                Thread.Sleep(250);
-                                SharedSerial.Transmit(":I#");
-                            }
-                            catch (System.IO.IOException exception) {
-                                MessageBox.Show("Serial port not opened for " + SharedResources.SharedSerial.PortName,
-                                    "Invalid port state", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                                SharedResources.tl.LogMessage("Serial port not opened", exception.Message);
-                            }
-                            catch (System.UnauthorizedAccessException exception) {
-                                MessageBox.Show("Access denied to serial port " + SharedResources.SharedSerial.PortName,
-                                    "Access denied", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                                SharedResources.tl.LogMessage("Access denied to serial port", exception.Message);
-                            }
-                            catch (ASCOM.DriverAccessCOMException exception) {
-                                MessageBox.Show("ASCOM driver exception: " + exception.Message,
-                                    "ASCOM driver exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                            }
-                            catch (System.Runtime.InteropServices.COMException exception) {
-                                MessageBox.Show(
-                                    "Serial port read timeout for port " + SharedResources.SharedSerial.PortName,
-                                    "Timeout", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                                SharedResources.tl.LogMessage("Serial port read timeout", exception.Message);
-                            }
-                        }
+								Thread.Sleep(1000);
+								SharedSerial.Transmit(":I#");
+							}
+							catch (System.IO.IOException exception)
+							{
+								MessageBox.Show("Serial port not opened for " + SharedResources.SharedSerial.PortName,
+									"Invalid port state", MessageBoxButtons.OK, MessageBoxIcon.Error);
+								SharedResources.tl.LogMessage("Serial port not opened", exception.Message);
+							}
+							catch (System.UnauthorizedAccessException exception)
+							{
+								MessageBox.Show("Access denied to serial port " + SharedResources.SharedSerial.PortName,
+									"Access denied", MessageBoxButtons.OK, MessageBoxIcon.Error);
+								SharedResources.tl.LogMessage("Access denied to serial port", exception.Message);
+							}
+							catch (ASCOM.DriverAccessCOMException exception)
+							{
+								MessageBox.Show("ASCOM driver exception: " + exception.Message,
+									"ASCOM driver exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
+							}
+							catch (System.Runtime.InteropServices.COMException exception)
+							{
+								MessageBox.Show(
+									"Serial port read timeout for port " + SharedResources.SharedSerial.PortName,
+									"Timeout", MessageBoxButtons.OK, MessageBoxIcon.Error);
+								SharedResources.tl.LogMessage("Serial port read timeout", exception.Message);
+							}
+						}
 
-                        Connections++;
-                        tl.LogMessage("Connected Set", $"{value} - Connection Count is {Connections} Clients");
-                    }
-                    else {
-                        Connections--;
-                        tl.LogMessage("Connected Set", $"{value} - Connection Count is {Connections} Clients");
-                        if (Connections <= 0) {
-                            Connections = 0;
-                            tl.LogMessage("Connection Set",
-                                $"Connection Count is {Connections} Disconnecting From Device");
-                            SharedSerial.Transmit(":Qq#");
-                            SharedSerial.Connected = false;
-                        }
-                    }
-                }
-            }
-            get => SharedSerial.Connected;
-        }
+						Connections++;
+						tl.LogMessage("Connected Set", $"{value} - Connection Count is {Connections} Clients");
+					}
+					else
+					{
+						Connections--;
+						tl.LogMessage("Connected Set", $"{value} - Connection Count is {Connections} Clients");
+						if (Connections <= 0)
+						{
+							Connections = 0;
+							tl.LogMessage("Connection Set",
+								$"Connection Count is {Connections} Disconnecting From Device");
+							SharedSerial.Transmit(":Qq#");
+							SharedSerial.Connected = false;
+						}
+					}
+				}
+			}
+			get => SharedSerial.Connected;
+		}
 
-        #endregion
 
-        /// <summary>
-        /// Skeleton of a hardware class, all this does is hold a count of the connections,
-        /// in reality extra code will be needed to handle the hardware in some way
-        /// </summary>
-        public class DeviceHardware {
-            internal int count { set; get; }
+		/// <summary>
+		/// Required Interface functions for ASCOM, apparently.
+		/// </summary>
+		/// <param name="message"></param>
+		/// <returns></returns>
+		public static string SendMessageString(string message)
+		{
+			try
+			{
+				string answer = SharedResources.SendMessage(message);
+				return answer;
+			}
+			catch
+			{
+				return "";
+			}
+		}
 
-            internal DeviceHardware() {
-                count = 0;
-            }
-        }
+		/// <summary>
+		/// Required Interface functions for ASCOM, apparently.
+		/// </summary>
+		public static void SendMessageBlind(string message)
+		{
+			try
+			{
+				string answer = SharedResources.SendMessage(message);
+			}
+			catch { }
+		}
 
-        public static string SendMessageString(string message) {
-            try {
-                string answer = SharedResources.SendMessage(message, true);
-                return answer;
-            }
-            catch {
-                return "";
-            }
-        }
+		#endregion
 
-        //Add new public methods here
+		/// <summary>
+		/// Skeleton of a hardware class, all this does is hold a count of the connections,
+		/// in reality extra code will be needed to handle the hardware in some way
+		/// </summary>
+		public class DeviceHardware
+		{
+			internal int count { set; get; }
 
-        public static void SendMessageBlind(string message) {
-            try {
-                string answer = SharedResources.SendMessage(message, false);
-            }
-            catch { }
-        }
-    }
+			internal DeviceHardware()
+			{
+				count = 0;
+			}
+		}
+	}
 }

--- a/ASCOM.Driver/TelescopeDriver/Properties/AssemblyInfo.cs
+++ b/ASCOM.Driver/TelescopeDriver/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 //
 // TODO - Set your driver's version here
-[assembly: AssemblyVersion("6.5.2.0")]
-[assembly: AssemblyFileVersion("6.5.2.0")]
+[assembly: AssemblyVersion("6.5.3.0")]
+[assembly: AssemblyFileVersion("6.5.3.0")]

--- a/ASCOM.Driver/TelescopeDriver/Rates.cs
+++ b/ASCOM.Driver/TelescopeDriver/Rates.cs
@@ -97,18 +97,18 @@ namespace ASCOM.OpenAstroTracker
                 case TelescopeAxes.axisPrimary:
                     // Example: m_Rates = new Rate[] { new Rate(10.5, 30.2), new Rate(54.0, 43.6) }
                     rates = new Rate[] {
-                        new Rate(0.05d, 0.3d),  // 0.18 degrees/sec  // Measured on my OAT with NEMA17 and TMC2009 UART
-                        new Rate(0.3d, 0.9d),   // 0.7
-                        new Rate(0.9d, 1.9d),    // 1.6
-                        new Rate(1.9d, 2.5d)     // 2.5
+                        new Rate(0.05d, 0.299d),  // 0.18 degrees/sec  // Measured on my OAT with NEMA17 and TMC2209 UART
+                        new Rate(0.3d, 0.899d),   // 0.7
+                        new Rate(0.9d, 1.899d),   // 1.6
+                        new Rate(1.9d, 2.5d)      // 2.5
                       };
                     break;
                 case TelescopeAxes.axisSecondary:
                     rates = new Rate[] {
-                        new Rate(0.05d, 0.3d),   // 0.2
-                        new Rate(0.3d, 0.9d),    // 0.8
-                        new Rate(1.9d, 1.9d),     // 1.8
-                        new Rate(1.9d, 2.5d)      // 2.3
+                        new Rate(0.05d, 0.299d),   // 0.2
+                        new Rate(0.3d, 0.899d),    // 0.8
+                        new Rate(0.9d, 1.899d),    // 1.8
+                        new Rate(1.9d, 2.5d)       // 2.3
                     };
                     break;
                 case TelescopeAxes.axisTertiary:

--- a/ASCOM.Driver/TelescopeDriver/SetupDialogForm.cs
+++ b/ASCOM.Driver/TelescopeDriver/SetupDialogForm.cs
@@ -3,89 +3,130 @@ using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
-namespace ASCOM.OpenAstroTracker {
-    [ComVisible(false)] // Form not registered for COM!
-    public partial class SetupDialogForm : Form {
-        private ProfileData _profile;
+namespace ASCOM.OpenAstroTracker
+{
+	[ComVisible(false)] // Form not registered for COM!
+	public partial class SetupDialogForm : Form
+	{
+		private ProfileData _profile;
 
-        public SetupDialogForm(ProfileData profile) {
-            _profile = profile;
-            InitializeComponent();
+		public SetupDialogForm(ProfileData profile)
+		{
+			_profile = profile;
+			InitializeComponent();
 
-            Text = $"OpenAstroTracker Setup - {Version}";
-        }
+			Text = $"OpenAstroTracker Setup - {Version}";
+		}
 
-        private string Version => GetType().Assembly.GetName().Version.ToString();
+		private string Version => GetType().Assembly.GetName().Version.ToString();
 
-        private void OK_Button_Click(System.Object sender, System.EventArgs e) // OK button event handler
-        {
-            // Persist new values of user settings to the ASCOM profile
-            _profile.ComPort =
-                (string) ComboBoxComPort.SelectedItem; // Update the state variables with results from the dialogue
-            _profile.TraceState = chkTrace.Checked;
-            _profile.Latitude = System.Convert.ToDouble(txtLat.Text);
-            _profile.Longitude = System.Convert.ToDouble(txtLong.Text);
-            _profile.Elevation = System.Convert.ToInt32(txtElevation.Text);
-            this.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.Close();
-        }
+		private void OK_Button_Click(System.Object sender, System.EventArgs e) // OK button event handler
+		{
+			// Persist new values of user settings to the ASCOM profile
+			// Update the state variables with results from the dialogue
+			_profile.ComPort = (string)ComboBoxComPort.SelectedItem;
+			_profile.BaudRate = Convert.ToInt64(comboBoxBaudRate.SelectedItem);
+			_profile.TraceState = chkTrace.Checked;
+			_profile.Latitude = System.Convert.ToDouble(txtLat.Text);
+			_profile.Longitude = System.Convert.ToDouble(txtLong.Text);
+			_profile.Elevation = System.Convert.ToInt32(txtElevation.Text);
+			this.DialogResult = System.Windows.Forms.DialogResult.OK;
+			this.Close();
+		}
 
-        public ProfileData GetProfileData() => _profile;
+		public ProfileData GetProfileData() => _profile;
 
-        private void Cancel_Button_Click(System.Object sender, System.EventArgs e) // Cancel button event handler
-        {
-            this.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.Close();
-        }
+		private void Cancel_Button_Click(System.Object sender, System.EventArgs e) // Cancel button event handler
+		{
+			this.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+			this.Close();
+		}
 
-        private void ShowAscomWebPage(System.Object sender, System.EventArgs e) {
-            // Click on ASCOM logo event handler
-            try {
-                System.Diagnostics.Process.Start("http://ascom-standards.org/");
-            }
-            catch (Win32Exception noBrowser) {
-                if (noBrowser.ErrorCode == -2147467259)
-                    MessageBox.Show(noBrowser.Message);
-            }
-            catch (Exception other) {
-                MessageBox.Show(other.Message);
-            }
-        }
+		private void ShowAscomWebPage(System.Object sender, System.EventArgs e)
+		{
+			// Click on ASCOM logo event handler
+			try
+			{
+				System.Diagnostics.Process.Start("http://ascom-standards.org/");
+			}
+			catch (Win32Exception noBrowser)
+			{
+				if (noBrowser.ErrorCode == -2147467259)
+					MessageBox.Show(noBrowser.Message);
+			}
+			catch (Exception other)
+			{
+				MessageBox.Show(other.Message);
+			}
+		}
 
-        private void SetupDialogForm_Load(System.Object sender, System.EventArgs e) // Form load event handler
-        {
-            // Retrieve current values of user settings from the ASCOM Profile
-            InitUI();
-        }
+		private void ShowOATWebPage(System.Object sender, System.EventArgs e)
+		{
+			// Click on OAT logo event handler
+			try
+			{
+				System.Diagnostics.Process.Start("https://wiki.openastrotech.com/");
+			}
+			catch (Win32Exception noBrowser)
+			{
+				if (noBrowser.ErrorCode == -2147467259)
+					MessageBox.Show(noBrowser.Message);
+			}
+			catch (Exception other)
+			{
+				MessageBox.Show(other.Message);
+			}
+		}
 
-        private void InitUI() {
-            chkTrace.Checked = _profile.TraceState;
-            // set the list of com ports to those that are currently available
-            ComboBoxComPort.Items.Clear();
-            ComboBoxComPort.Items.AddRange(System.IO.Ports.SerialPort.GetPortNames()); // use System.IO because it's static
-            // select the current port if possible...
-            if (ComboBoxComPort.Items.Contains(_profile.ComPort))
-                ComboBoxComPort.SelectedItem = _profile.ComPort;
-            txtLat.Text = _profile.Latitude.ToString();
-            txtLong.Text = _profile.Longitude.ToString();
-            txtElevation.Text = _profile.Elevation.ToString();
-        }
+		private void SetupDialogForm_Load(System.Object sender, System.EventArgs e) // Form load event handler
+		{
+			// Retrieve current values of user settings from the ASCOM Profile
+			InitUI();
+		}
 
-        private void txtLat_KeyPress(object sender, KeyPressEventArgs e) {
-            if (!char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar) && e.KeyChar != '.' && e.KeyChar != ',' &&
-                e.KeyChar != '-')
-                e.Handled = true;
-        }
+		private void InitUI()
+		{
+			chkTrace.Checked = _profile.TraceState;
 
-        private void txtLong_KeyPress(object sender, KeyPressEventArgs e) {
-            if (!char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar) && e.KeyChar != '.' && e.KeyChar != ',' &&
-                e.KeyChar != '-')
-                e.Handled = true;
-        }
+			// Set the list of com ports to those that are currently available using System.IO because it's static
+			ComboBoxComPort.Items.Clear();
+			ComboBoxComPort.Items.AddRange(System.IO.Ports.SerialPort.GetPortNames());
+			comboBoxBaudRate.Items.AddRange(new string[] { "57600", "28800", "14400", "9600", "2400", "1200", "300"});
 
-        private void txtElevation_KeyPress(object sender, KeyPressEventArgs e) {
-            if (!char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar))
-                e.Handled = true;
-        }
-    }
+			// Select the current port and baudrate if possible...
+			if (ComboBoxComPort.Items.Contains(_profile.ComPort))
+			{
+				ComboBoxComPort.SelectedItem = _profile.ComPort;
+			}
+
+			if (comboBoxBaudRate.Items.Contains(_profile.BaudRate.ToString()))
+			{
+				comboBoxBaudRate.SelectedItem = _profile.BaudRate.ToString();
+			}
+
+			txtLat.Text = _profile.Latitude.ToString();
+			txtLong.Text = _profile.Longitude.ToString();
+			txtElevation.Text = _profile.Elevation.ToString();
+		}
+
+		private void txtLat_KeyPress(object sender, KeyPressEventArgs e)
+		{
+			if (!char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar) && e.KeyChar != '.' && e.KeyChar != ',' &&
+				e.KeyChar != '-')
+				e.Handled = true;
+		}
+
+		private void txtLong_KeyPress(object sender, KeyPressEventArgs e)
+		{
+			if (!char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar) && e.KeyChar != '.' && e.KeyChar != ',' &&
+				e.KeyChar != '-')
+				e.Handled = true;
+		}
+
+		private void txtElevation_KeyPress(object sender, KeyPressEventArgs e)
+		{
+			if (!char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar))
+				e.Handled = true;
+		}
+	}
 }

--- a/ASCOM.Driver/TelescopeDriver/SetupDialogForm.designer.cs
+++ b/ASCOM.Driver/TelescopeDriver/SetupDialogForm.designer.cs
@@ -43,6 +43,8 @@ namespace ASCOM.OpenAstroTracker
 			this.OK_Button = new System.Windows.Forms.Button();
 			this.Cancel_Button = new System.Windows.Forms.Button();
 			this.pictureBox2 = new System.Windows.Forms.PictureBox();
+			this.comboBoxBaudRate = new System.Windows.Forms.ComboBox();
+			this.label6 = new System.Windows.Forms.Label();
 			((System.ComponentModel.ISupportInitialize)(this.PictureBox1)).BeginInit();
 			this.TableLayoutPanel1.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
@@ -51,7 +53,7 @@ namespace ASCOM.OpenAstroTracker
 			// Label5
 			// 
 			this.Label5.AutoSize = true;
-			this.Label5.Location = new System.Drawing.Point(49, 109);
+			this.Label5.Location = new System.Drawing.Point(55, 138);
 			this.Label5.Name = "Label5";
 			this.Label5.Size = new System.Drawing.Size(72, 13);
 			this.Label5.TabIndex = 28;
@@ -59,7 +61,7 @@ namespace ASCOM.OpenAstroTracker
 			// 
 			// txtElevation
 			// 
-			this.txtElevation.Location = new System.Drawing.Point(135, 106);
+			this.txtElevation.Location = new System.Drawing.Point(135, 135);
 			this.txtElevation.Name = "txtElevation";
 			this.txtElevation.Size = new System.Drawing.Size(84, 20);
 			this.txtElevation.TabIndex = 27;
@@ -67,7 +69,7 @@ namespace ASCOM.OpenAstroTracker
 			// Label4
 			// 
 			this.Label4.AutoSize = true;
-			this.Label4.Location = new System.Drawing.Point(55, 57);
+			this.Label4.Location = new System.Drawing.Point(61, 86);
 			this.Label4.Name = "Label4";
 			this.Label4.Size = new System.Drawing.Size(66, 13);
 			this.Label4.TabIndex = 26;
@@ -76,7 +78,7 @@ namespace ASCOM.OpenAstroTracker
 			// Label3
 			// 
 			this.Label3.AutoSize = true;
-			this.Label3.Location = new System.Drawing.Point(46, 83);
+			this.Label3.Location = new System.Drawing.Point(52, 112);
 			this.Label3.Name = "Label3";
 			this.Label3.Size = new System.Drawing.Size(75, 13);
 			this.Label3.TabIndex = 25;
@@ -84,14 +86,14 @@ namespace ASCOM.OpenAstroTracker
 			// 
 			// txtLong
 			// 
-			this.txtLong.Location = new System.Drawing.Point(135, 80);
+			this.txtLong.Location = new System.Drawing.Point(135, 109);
 			this.txtLong.Name = "txtLong";
 			this.txtLong.Size = new System.Drawing.Size(84, 20);
 			this.txtLong.TabIndex = 24;
 			// 
 			// txtLat
 			// 
-			this.txtLat.Location = new System.Drawing.Point(135, 54);
+			this.txtLat.Location = new System.Drawing.Point(135, 83);
 			this.txtLat.Name = "txtLat";
 			this.txtLat.Size = new System.Drawing.Size(84, 20);
 			this.txtLat.TabIndex = 23;
@@ -99,7 +101,7 @@ namespace ASCOM.OpenAstroTracker
 			// Label2
 			// 
 			this.Label2.AutoSize = true;
-			this.Label2.Location = new System.Drawing.Point(4, 33);
+			this.Label2.Location = new System.Drawing.Point(10, 60);
 			this.Label2.Name = "Label2";
 			this.Label2.Size = new System.Drawing.Size(117, 13);
 			this.Label2.TabIndex = 22;
@@ -116,7 +118,7 @@ namespace ASCOM.OpenAstroTracker
 			// chkTrace
 			// 
 			this.chkTrace.AutoSize = true;
-			this.chkTrace.Location = new System.Drawing.Point(135, 33);
+			this.chkTrace.Location = new System.Drawing.Point(135, 61);
 			this.chkTrace.Name = "chkTrace";
 			this.chkTrace.Size = new System.Drawing.Size(15, 14);
 			this.chkTrace.TabIndex = 20;
@@ -138,11 +140,11 @@ namespace ASCOM.OpenAstroTracker
 			// Label1
 			// 
 			this.Label1.AutoSize = true;
-			this.Label1.Location = new System.Drawing.Point(12, 9);
+			this.Label1.Location = new System.Drawing.Point(74, 9);
 			this.Label1.Name = "Label1";
-			this.Label1.Size = new System.Drawing.Size(109, 13);
+			this.Label1.Size = new System.Drawing.Size(53, 13);
 			this.Label1.TabIndex = 18;
-			this.Label1.Text = "Select your COM Port";
+			this.Label1.Text = "COM Port";
 			// 
 			// TableLayoutPanel1
 			// 
@@ -152,7 +154,7 @@ namespace ASCOM.OpenAstroTracker
 			this.TableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
 			this.TableLayoutPanel1.Controls.Add(this.OK_Button, 0, 0);
 			this.TableLayoutPanel1.Controls.Add(this.Cancel_Button, 1, 0);
-			this.TableLayoutPanel1.Location = new System.Drawing.Point(164, 154);
+			this.TableLayoutPanel1.Location = new System.Drawing.Point(164, 173);
 			this.TableLayoutPanel1.Name = "TableLayoutPanel1";
 			this.TableLayoutPanel1.RowCount = 1;
 			this.TableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
@@ -183,22 +185,41 @@ namespace ASCOM.OpenAstroTracker
 			// pictureBox2
 			// 
 			this.pictureBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.pictureBox2.Cursor = System.Windows.Forms.Cursors.Arrow;
-			this.pictureBox2.Enabled = false;
+			this.pictureBox2.Cursor = System.Windows.Forms.Cursors.Hand;
 			this.pictureBox2.Image = global::ASCOM.OpenAstroTracker.Properties.Resources.OATAscom;
-			this.pictureBox2.Location = new System.Drawing.Point(236, 68);
+			this.pictureBox2.Location = new System.Drawing.Point(237, 84);
 			this.pictureBox2.Name = "pictureBox2";
 			this.pictureBox2.Size = new System.Drawing.Size(87, 71);
 			this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
 			this.pictureBox2.TabIndex = 29;
 			this.pictureBox2.TabStop = false;
+			this.pictureBox2.Click += new System.EventHandler(this.ShowOATWebPage);
+			// 
+			// comboBoxBaudRate
+			// 
+			this.comboBoxBaudRate.FormattingEnabled = true;
+			this.comboBoxBaudRate.Location = new System.Drawing.Point(135, 30);
+			this.comboBoxBaudRate.Name = "comboBoxBaudRate";
+			this.comboBoxBaudRate.Size = new System.Drawing.Size(84, 21);
+			this.comboBoxBaudRate.TabIndex = 31;
+			// 
+			// label6
+			// 
+			this.label6.AutoSize = true;
+			this.label6.Location = new System.Drawing.Point(69, 33);
+			this.label6.Name = "label6";
+			this.label6.Size = new System.Drawing.Size(58, 13);
+			this.label6.TabIndex = 30;
+			this.label6.Text = "Baud Rate";
 			// 
 			// SetupDialogForm
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.BackColor = System.Drawing.SystemColors.Control;
-			this.ClientSize = new System.Drawing.Size(322, 195);
+			this.ClientSize = new System.Drawing.Size(322, 214);
+			this.Controls.Add(this.comboBoxBaudRate);
+			this.Controls.Add(this.label6);
 			this.Controls.Add(this.pictureBox2);
 			this.Controls.Add(this.Label5);
 			this.Controls.Add(this.txtElevation);
@@ -245,5 +266,7 @@ namespace ASCOM.OpenAstroTracker
         internal System.Windows.Forms.Button OK_Button;
         internal System.Windows.Forms.Button Cancel_Button;
 		internal System.Windows.Forms.PictureBox pictureBox2;
+		internal System.Windows.Forms.ComboBox comboBoxBaudRate;
+		internal System.Windows.Forms.Label label6;
 	}
 }

--- a/ASCOM.Driver/TelescopeDriver/SetupDialogForm.designer.cs
+++ b/ASCOM.Driver/TelescopeDriver/SetupDialogForm.designer.cs
@@ -45,6 +45,8 @@ namespace ASCOM.OpenAstroTracker
 			this.pictureBox2 = new System.Windows.Forms.PictureBox();
 			this.comboBoxBaudRate = new System.Windows.Forms.ComboBox();
 			this.label6 = new System.Windows.Forms.Label();
+			this.label7 = new System.Windows.Forms.Label();
+			this.label8 = new System.Windows.Forms.Label();
 			((System.ComponentModel.ISupportInitialize)(this.PictureBox1)).BeginInit();
 			this.TableLayoutPanel1.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
@@ -53,7 +55,7 @@ namespace ASCOM.OpenAstroTracker
 			// Label5
 			// 
 			this.Label5.AutoSize = true;
-			this.Label5.Location = new System.Drawing.Point(55, 138);
+			this.Label5.Location = new System.Drawing.Point(55, 184);
 			this.Label5.Name = "Label5";
 			this.Label5.Size = new System.Drawing.Size(72, 13);
 			this.Label5.TabIndex = 28;
@@ -61,7 +63,7 @@ namespace ASCOM.OpenAstroTracker
 			// 
 			// txtElevation
 			// 
-			this.txtElevation.Location = new System.Drawing.Point(135, 135);
+			this.txtElevation.Location = new System.Drawing.Point(135, 181);
 			this.txtElevation.Name = "txtElevation";
 			this.txtElevation.Size = new System.Drawing.Size(84, 20);
 			this.txtElevation.TabIndex = 27;
@@ -69,7 +71,7 @@ namespace ASCOM.OpenAstroTracker
 			// Label4
 			// 
 			this.Label4.AutoSize = true;
-			this.Label4.Location = new System.Drawing.Point(61, 86);
+			this.Label4.Location = new System.Drawing.Point(61, 132);
 			this.Label4.Name = "Label4";
 			this.Label4.Size = new System.Drawing.Size(66, 13);
 			this.Label4.TabIndex = 26;
@@ -78,7 +80,7 @@ namespace ASCOM.OpenAstroTracker
 			// Label3
 			// 
 			this.Label3.AutoSize = true;
-			this.Label3.Location = new System.Drawing.Point(52, 112);
+			this.Label3.Location = new System.Drawing.Point(52, 158);
 			this.Label3.Name = "Label3";
 			this.Label3.Size = new System.Drawing.Size(75, 13);
 			this.Label3.TabIndex = 25;
@@ -86,14 +88,14 @@ namespace ASCOM.OpenAstroTracker
 			// 
 			// txtLong
 			// 
-			this.txtLong.Location = new System.Drawing.Point(135, 109);
+			this.txtLong.Location = new System.Drawing.Point(135, 155);
 			this.txtLong.Name = "txtLong";
 			this.txtLong.Size = new System.Drawing.Size(84, 20);
 			this.txtLong.TabIndex = 24;
 			// 
 			// txtLat
 			// 
-			this.txtLat.Location = new System.Drawing.Point(135, 83);
+			this.txtLat.Location = new System.Drawing.Point(135, 129);
 			this.txtLat.Name = "txtLat";
 			this.txtLat.Size = new System.Drawing.Size(84, 20);
 			this.txtLat.TabIndex = 23;
@@ -101,7 +103,7 @@ namespace ASCOM.OpenAstroTracker
 			// Label2
 			// 
 			this.Label2.AutoSize = true;
-			this.Label2.Location = new System.Drawing.Point(10, 60);
+			this.Label2.Location = new System.Drawing.Point(10, 106);
 			this.Label2.Name = "Label2";
 			this.Label2.Size = new System.Drawing.Size(117, 13);
 			this.Label2.TabIndex = 22;
@@ -118,7 +120,7 @@ namespace ASCOM.OpenAstroTracker
 			// chkTrace
 			// 
 			this.chkTrace.AutoSize = true;
-			this.chkTrace.Location = new System.Drawing.Point(135, 61);
+			this.chkTrace.Location = new System.Drawing.Point(135, 107);
 			this.chkTrace.Name = "chkTrace";
 			this.chkTrace.Size = new System.Drawing.Size(15, 14);
 			this.chkTrace.TabIndex = 20;
@@ -129,7 +131,7 @@ namespace ASCOM.OpenAstroTracker
 			this.PictureBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
 			this.PictureBox1.Cursor = System.Windows.Forms.Cursors.Hand;
 			this.PictureBox1.Image = global::ASCOM.OpenAstroTracker.Properties.Resources.ASCOM;
-			this.PictureBox1.Location = new System.Drawing.Point(262, 6);
+			this.PictureBox1.Location = new System.Drawing.Point(256, 6);
 			this.PictureBox1.Name = "PictureBox1";
 			this.PictureBox1.Size = new System.Drawing.Size(48, 56);
 			this.PictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
@@ -154,7 +156,7 @@ namespace ASCOM.OpenAstroTracker
 			this.TableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
 			this.TableLayoutPanel1.Controls.Add(this.OK_Button, 0, 0);
 			this.TableLayoutPanel1.Controls.Add(this.Cancel_Button, 1, 0);
-			this.TableLayoutPanel1.Location = new System.Drawing.Point(164, 173);
+			this.TableLayoutPanel1.Location = new System.Drawing.Point(158, 227);
 			this.TableLayoutPanel1.Name = "TableLayoutPanel1";
 			this.TableLayoutPanel1.RowCount = 1;
 			this.TableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
@@ -187,7 +189,7 @@ namespace ASCOM.OpenAstroTracker
 			this.pictureBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
 			this.pictureBox2.Cursor = System.Windows.Forms.Cursors.Hand;
 			this.pictureBox2.Image = global::ASCOM.OpenAstroTracker.Properties.Resources.OATAscom;
-			this.pictureBox2.Location = new System.Drawing.Point(237, 84);
+			this.pictureBox2.Location = new System.Drawing.Point(231, 130);
 			this.pictureBox2.Name = "pictureBox2";
 			this.pictureBox2.Size = new System.Drawing.Size(87, 71);
 			this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
@@ -212,12 +214,32 @@ namespace ASCOM.OpenAstroTracker
 			this.label6.TabIndex = 30;
 			this.label6.Text = "Baud Rate";
 			// 
+			// label7
+			// 
+			this.label7.Location = new System.Drawing.Point(47, 60);
+			this.label7.Name = "label7";
+			this.label7.Size = new System.Drawing.Size(185, 40);
+			this.label7.TabIndex = 32;
+			this.label7.Text = "Firmware V1.9.03 and earlier used 57600, while later version use 28800.";
+			// 
+			// label8
+			// 
+			this.label8.AutoSize = true;
+			this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label8.Location = new System.Drawing.Point(10, 60);
+			this.label8.Name = "label8";
+			this.label8.Size = new System.Drawing.Size(38, 13);
+			this.label8.TabIndex = 33;
+			this.label8.Text = "Note:";
+			// 
 			// SetupDialogForm
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.BackColor = System.Drawing.SystemColors.Control;
-			this.ClientSize = new System.Drawing.Size(322, 214);
+			this.ClientSize = new System.Drawing.Size(316, 268);
+			this.Controls.Add(this.label8);
+			this.Controls.Add(this.label7);
 			this.Controls.Add(this.comboBoxBaudRate);
 			this.Controls.Add(this.label6);
 			this.Controls.Add(this.pictureBox2);
@@ -268,5 +290,7 @@ namespace ASCOM.OpenAstroTracker
 		internal System.Windows.Forms.PictureBox pictureBox2;
 		internal System.Windows.Forms.ComboBox comboBoxBaudRate;
 		internal System.Windows.Forms.Label label6;
+		internal System.Windows.Forms.Label label7;
+		internal System.Windows.Forms.Label label8;
 	}
 }


### PR DESCRIPTION
- Synced up version numbers between OpenAstroTracker and Telescope driver
- Added Baud rate support to the profile dialog
- Made sure all commands are correctly configured for no reply, number reply or string reply and consolidated handling this in one function.
- Added some extra logging around what is being sent and received.
- Reformated source code to the standard C# style.
- Made driver rates not overlap.
- Added Altitude and Azimuth getters and calculated them from RA/DEC
- Made the OAT logo on the properties dialog take the user to the wiki when clicked.