### PR TITLE
OATControl V1.0.0.2

### DIFF
--- a/ASCOM.Driver/OpenAstroTracker/README.txt
+++ b/ASCOM.Driver/OpenAstroTracker/README.txt
@@ -2,11 +2,11 @@
 OpenAstroTracker ASCOM Driver 
 =============================
 
-Version 6.5.4.0, published 11 April 2021
+Version 6.5.4.0, published 14 April 2021
 ----------------------------------------
 
 * History
-	* 6.5.4.0	2021-04-11		:		CHANGE : Changed available and default baud rate(s).
+	* 6.5.4.0	2021-04-14		:		CHANGE : Changed available and default baud rate(s).
 	* 6.5.3.0	2021-04-10		:		CHANGE : Fixed Sync command. Added choosable baudrate. Lots of bug fixes.
 	* 0.3.1.0	2021-03-20		:		CHANGE : Added Rates support and fixed a bug causing an error in MoveAxis.
 	* 0.3.0.0	2020-11-30		:		CHANGE : Added move with slewrate support, stable release

--- a/OATCommunications.WPF/CommunicationHandlers/CommunicationHandlerFactory.cs
+++ b/OATCommunications.WPF/CommunicationHandlers/CommunicationHandlerFactory.cs
@@ -48,7 +48,12 @@ namespace OATCommunications.WPF.CommunicationHandlers
 
 		public static ICommunicationHandler ConnectToDevice(string device)
 		{
-			Log.WriteLine($"COMMFACTORY: Attempting to connect to device {device}...");
+			if (string.IsNullOrEmpty(device))
+			{
+				return null;
+			}
+
+			Log.WriteLine($"COMMFACTORY: Attempting to connect to device {device}...");//
 			if (device.StartsWith("Serial : "))
 			{
 				string comPort = device.Substring("Serial : ".Length);

--- a/OATControl/App.config
+++ b/OATControl/App.config
@@ -34,6 +34,18 @@
             <setting name="TargetChooserSize" serializeAs="String">
                 <value>670, 910</value>
             </setting>
+            <setting name="ShowDecLimits" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="LowerDecLimit" serializeAs="String">
+                <value>-90</value>
+            </setting>
+            <setting name="UpperDecLimit" serializeAs="String">
+                <value>180</value>
+            </setting>
+            <setting name="BaudRate" serializeAs="String">
+                <value>19200</value>
+            </setting>
         </OATControl.Properties.Settings>
     </userSettings>
 </configuration>

--- a/OATControl/Controls/RangeSlider.xaml
+++ b/OATControl/Controls/RangeSlider.xaml
@@ -1,0 +1,262 @@
+﻿<UserControl x:Class="OATControl.Controls.RangeSlider"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:convert="clr-namespace:OATControl.Converters"
+             Name="RangeSliderControl"
+             mc:Ignorable="d" 
+             d:DesignHeight="30" d:DesignWidth="300">
+
+	<UserControl.Resources>
+
+		<convert:BoolToVisibilityConverter x:Key="BoolToVisibleConverter"  Collapse="True" />
+		<convert:BoolToVisibilityConverter x:Key="BoolToHiddenConverter"  IsReversed="True" />
+		<convert:OrientationToVisibilityConverter x:Key="VerticalToVisibleConverter" VisibleOrientation="Vertical" Collapse="True" />
+		<convert:OrientationToVisibilityConverter x:Key="HorizontalToVisibleConverter" VisibleOrientation="Horizontal" Collapse="True" />
+
+		<SolidColorBrush x:Key="TextColor" Color="#F7F7"/>
+		<SolidColorBrush x:Key="UnsetBackground" Color="#F600"/>
+		<SolidColorBrush x:Key="UnsetBorder" Color="#F400"/>
+		<SolidColorBrush x:Key="SetBackground" Color="#F811"/>
+		<SolidColorBrush x:Key="SetBackgroundActive" Color="#FD11"/>
+		<SolidColorBrush x:Key="SetBorder" Color="#F911"/>
+		<SolidColorBrush x:Key="ValueBorder" Color="#FF21"/>
+		<SolidColorBrush x:Key="ValueFill" Color="#FF21"/>
+		<SolidColorBrush x:Key="MarkerValueBorder" Color="#F000"/>
+		<SolidColorBrush x:Key="MarkerValueFill" Color="#F000"/>
+		<SolidColorBrush x:Key="Gray06" Color="#F111"/>
+		<Color x:Key="ColorGray60"  A="0xFF" R="0x99" G="0x99" B="0x99" />
+
+	</UserControl.Resources>
+	<Grid>
+		<Grid Name="MainVGrid" Background="Transparent" IsHitTestVisible="True" MouseDown="MainGrid_OnMouseButtonDown" MouseUp="MainGrid_OnMouseButtonUp" MouseMove="MainGrid_OnMouseMove" Visibility="{Binding ElementName=RangeSliderControl, Path=Orientation, Converter={StaticResource VerticalToVisibleConverter}}">
+			<!--<Grid Name="MainVGrid" Background="Transparent" IsHitTestVisible="True" MouseDown="MainGrid_OnMouseButtonDown" MouseUp="MainGrid_OnMouseButtonUp" MouseMove="MainGrid_OnMouseMove" Visibility="Hidden">-->
+				<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="{Binding ElementName=RangeSliderControl, Path=LabelColumnSize}" />
+				<ColumnDefinition Width="*"/>
+			</Grid.ColumnDefinitions>
+			<Grid.RowDefinitions>
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+
+			<Grid Grid.Row="0" Grid.Column="0" >
+				<Canvas Name="TickLabelVCanvas" Margin="0,0,0,0" VerticalAlignment="Top" />
+			</Grid>
+
+			<Grid Grid.Row="0" Grid.Column="1" Name="TrackVPart" SizeChanged="TrackPart_OnSizeChanged" SnapsToDevicePixels="True" Margin="0,0,0,0">
+				<Grid.RowDefinitions>
+					<RowDefinition Height="5"/>
+					<RowDefinition Height="{Binding ElementName=RangeSliderControl, Path=UpperPartHeight}"/>
+					<RowDefinition Height="{Binding ElementName=RangeSliderControl, Path=SliderPartHeight}"/>
+					<RowDefinition Height="{Binding ElementName=RangeSliderControl, Path=LowerPartHeight}"/>
+					<RowDefinition Height="5"/>
+				</Grid.RowDefinitions>
+
+
+				<!-- Middle Slider piece -->
+				<Border Grid.Row="2" BorderBrush="{StaticResource UnsetBorder}" BorderThickness="1,0,1,0"  Margin="8,0,2,0" 	>
+					<Rectangle Fill="{StaticResource UnsetBackground}" RadiusX="0" RadiusY="0"  />
+				</Border>
+
+
+				<!-- Value indicator -->
+				<Grid Grid.Row="0" Grid.RowSpan="5" Grid.Column="1" >
+					<Path Data="M0,-5 L-10,0 0,5 16,5 16,-5z" 
+					  Stretch="Uniform" 
+					  Fill="{StaticResource ValueFill}" 
+					  StrokeThickness="1"  
+					  Stroke="{StaticResource ValueBorder}" 
+					  Width="20" 
+					  Height="10" 
+					  VerticalAlignment="Top"
+					  Margin="{Binding ElementName=RangeSliderControl, Path=ValueMargin}"
+					  RenderTransformOrigin="0.5,0.5">
+					</Path>
+				</Grid>
+
+				<!-- Marker indicator -->
+				<Grid Grid.Row="0" Grid.RowSpan="5" Grid.Column="1" >
+					<Path Data="M0,-5 M0,-3 L-6,0 0,3 16,3 M16,5 M16,3 L16,-3 0,-3 M16,-5z" 
+					  Stretch="Uniform" 
+					  Fill="{StaticResource MarkerValueFill}" 
+					  StrokeThickness="1"  
+					  Stroke="{StaticResource MarkerValueBorder}" 
+					  Width="20" 
+					  Height="10" 
+					  VerticalAlignment="Top"
+					  Margin="{Binding ElementName=RangeSliderControl, Path=MarkerValueMargin}"
+					  RenderTransformOrigin="0.5,0.5">
+					</Path>
+				</Grid>
+
+				<!-- Upper limit with limits showing -->
+				<Border Grid.Row="1" 
+					BorderBrush="{StaticResource SetBorder}" 
+					BorderThickness="1,1,5,1" 
+					Width="{Binding ElementName=RangeSliderControl, Path=SliderPartWidth}"
+					Margin="6,0,0,0"
+					Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToVisibleConverter}}"
+						   >
+					<Rectangle Margin="0,0" Fill="{StaticResource SetBackground}" />
+				</Border>
+
+				<!-- Upper limit -->
+				<Border Grid.Row="1" BorderBrush="{StaticResource UnsetBorder}" BorderThickness="1,1,1,0"  Margin="8,0,2,0" Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToHiddenConverter}}">
+					<Rectangle Fill="{StaticResource UnsetBackground}" RadiusX="0" RadiusY="0"  />
+				</Border>
+
+				<!-- Lower limit -->
+				<Border Grid.Row="3" BorderBrush="{StaticResource UnsetBorder}" BorderThickness="1,0,1,1"  Margin="8,0,2,0" Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToHiddenConverter}}">
+					<Rectangle Fill="{StaticResource UnsetBackground}" RadiusX="0" RadiusY="0"  />
+				</Border>
+
+				<!-- Lower limit with limits showing -->
+				<Border Grid.Row="3" 
+					BorderBrush="{StaticResource SetBorder}" 
+					BorderThickness="1,1,1,1" 
+					Margin="6,0,0,0"
+						
+					Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToVisibleConverter}}">
+					<Rectangle Margin="0,0" Fill="{StaticResource SetBackground}" />
+				</Border>
+
+
+				<!-- Top Limit indicator handles -->
+				<Border Grid.Row="2"  
+					BorderThickness="0,3,0,0"
+					BorderBrush="#C11"
+					Width="{Binding ElementName=RangeSliderControl, Path=SliderPartWidth}"
+					Margin="5,-2,-1,0"
+					VerticalAlignment="Top"
+					Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToVisibleConverter}}"
+					>
+				</Border>
+
+				<!-- Bottom Limit indicator handles -->
+				<Border Grid.Row="2"  
+					BorderThickness="0,3,0,0"
+					BorderBrush="#C11"
+					Width="{Binding ElementName=RangeSliderControl, Path=SliderPartWidth}"
+					Margin="5,0,-1,-1"
+					VerticalAlignment="Bottom"
+					Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToVisibleConverter}}"
+					/>
+
+			</Grid>
+		</Grid>
+
+
+
+		<Grid Name="MainHGrid" Background="Transparent" IsHitTestVisible="True" MouseDown="MainGrid_OnMouseButtonDown" MouseUp="MainGrid_OnMouseButtonUp" MouseMove="MainGrid_OnMouseMove" Visibility="{Binding ElementName=RangeSliderControl,Path=Orientation, Converter={StaticResource HorizontalToVisibleConverter}}">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="{Binding ElementName=RangeSliderControl, Path=LabelColumnSize}" />
+				<RowDefinition Height="*"/>
+			</Grid.RowDefinitions>
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+
+			<Grid Grid.Row="0" Grid.Column="0" >
+				<Canvas Name="TickLabelHCanvas" Margin="0,0,0,0" HorizontalAlignment="Left" />
+			</Grid>
+
+			<Grid Grid.Row="1" Grid.Column="0" Name="TrackHPart" SizeChanged="TrackPart_OnSizeChanged" SnapsToDevicePixels="True" Margin="0,0,0,0">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="5"/>
+					<ColumnDefinition Width="{Binding ElementName=RangeSliderControl, Path=LowerPartHeight}"/>
+					<ColumnDefinition Width="{Binding ElementName=RangeSliderControl, Path=SliderPartHeight}"/>
+					<ColumnDefinition Width="{Binding ElementName=RangeSliderControl, Path=UpperPartHeight}"/>
+					<ColumnDefinition Width="5"/>
+				</Grid.ColumnDefinitions>
+
+				<Border Grid.Column="1" BorderBrush="{StaticResource UnsetBorder}" BorderThickness="1,1,0,1"  Margin="0,8,0,2" Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToHiddenConverter}}">
+					<Rectangle Fill="{StaticResource UnsetBackground}" RadiusX="0" RadiusY="0"  />
+				</Border>
+
+				<Border Grid.Column="3" BorderBrush="{StaticResource UnsetBorder}" BorderThickness="0,1,1,1"  Margin="0,8,0,2"	 Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToHiddenConverter}}"		>
+					<Rectangle Fill="{StaticResource UnsetBackground}" RadiusX="0" RadiusY="0"  />
+				</Border>
+
+				<Border Grid.Column="2" BorderBrush="{StaticResource UnsetBorder}" BorderThickness="0,1"  Margin="0,8,0,2"	 >
+					<Rectangle Fill="{StaticResource UnsetBackground}" RadiusX="0" RadiusY="0"  />
+				</Border>
+
+				<!-- Value Indicator -->
+				<Grid Grid.Column="0" Grid.ColumnSpan="5" Grid.Row="1" >
+					<Path Data="M-5,0 L0,-5 5,0 5,16 -5,16z" 
+						Stretch="Uniform" 
+						Fill="{StaticResource ValueFill}" 
+						StrokeThickness="1"  
+						Stroke="{StaticResource ValueBorder}" 
+						Width="10" 
+						Height="20" 
+						HorizontalAlignment="Left"
+						Margin="{Binding ElementName=RangeSliderControl, Path=ValueMargin}"
+						RenderTransformOrigin="0.5,0.5">
+					</Path>
+				</Grid>
+
+				<!-- Marker Indicator -->
+				<Grid Grid.Column="0" Grid.ColumnSpan="5" Grid.Row="1" >
+					<Path Data="M-5,0 M-3,0 L0,-6 3,0 3,16 M5,16 M3,16 L-3,16 -3,0 M-5,16z" 
+					  Stretch="Uniform" 
+					  Fill="{StaticResource MarkerValueFill}" 
+					  StrokeThickness="1"  
+					  Stroke="{StaticResource MarkerValueBorder}" 
+					  Width="10" 
+					  Height="20" 
+					  HorizontalAlignment="Left"
+					  Margin="{Binding ElementName=RangeSliderControl, Path=MarkerValueMargin}"
+					  RenderTransformOrigin="0.5,0.5">
+					</Path>
+				</Grid>
+
+				<!-- Left Slider piece when limits shown -->
+				<Border Grid.Column="1" 
+					BorderBrush="{StaticResource SetBorder}" 
+					BorderThickness="1,1,1,5" 
+					Height="{Binding ElementName=RangeSliderControl, Path=SliderPartWidth}"
+					Margin="0,6,0,0"
+					Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToVisibleConverter}}"
+					>
+					<Rectangle Margin="0,0" Fill="{StaticResource SetBackground}" />
+				</Border>
+
+				<!-- Right Slider piece when limits shown -->
+				<Border Grid.Column="3" 
+					BorderBrush="{StaticResource SetBorder}" 
+					BorderThickness="1,1,1,5" 
+					Height="{Binding ElementName=RangeSliderControl, Path=SliderPartWidth}"
+					Margin="0,6,0,0"
+					Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToVisibleConverter}}"
+					>
+					<Rectangle Margin="0,0" Fill="{StaticResource SetBackground}" />
+				</Border>
+
+				<!-- Left Limit marker -->
+				<Border Grid.Column="2"  
+					BorderThickness="3,0,0,0"
+					BorderBrush="#C11"
+					Width="{Binding ElementName=RangeSliderControl, Path=SliderPartWidth}"
+					Margin="0,3,-2,-1"
+					HorizontalAlignment="Left"
+					Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToVisibleConverter}}"
+					>
+				</Border>
+
+				<!-- Right Limit marker -->
+				<Border Grid.Column="2"  
+					BorderThickness="0,0,3,0"
+					BorderBrush="#C11"
+					Width="{Binding ElementName=RangeSliderControl, Path=SliderPartWidth}"
+					Margin="-1,3,0,-1"
+					HorizontalAlignment="Right"
+					Visibility="{Binding ElementName=RangeSliderControl,Path=ShowLimits,Converter={StaticResource BoolToVisibleConverter}}"
+					/>
+
+			</Grid>
+		</Grid>
+	</Grid>
+</UserControl>
+

--- a/OATControl/Controls/RangeSlider.xaml.cs
+++ b/OATControl/Controls/RangeSlider.xaml.cs
@@ -1,0 +1,1160 @@
+﻿namespace OATControl.Controls
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Windows;
+	using System.Windows.Controls;
+	using System.Windows.Input;
+	using System.Windows.Media;
+	using System.Windows.Shapes;
+
+	/// <summary>
+	/// Interaction logic for RangeSlider.xaml
+	/// This is a range slider that has a current value indicater. Range can be edited.
+	/// 
+	/// The typical usage in a XAML file is:
+	///           &lt;RangeSlider Padding="3" 
+	///                 AxisLabel="Y Axis" 
+	///                 Minimum="0" 
+	///                 Maximum="112" 
+	///                 Value="{Binding Degrees, Mode=TwoWay}" 
+	///                 TickStart="0" 
+	///                 TickEnd="120" 
+	///                 TickMinorSpacing="10" 
+	///                 TickMajorSpacing="50" 
+	///                 TickLabels="0|50|100|120" 
+	///                /&gt;
+	/// 
+	/// - TickLabels are optional; if they are left off, no labels will be displayed next to the slider.
+	/// 
+	/// </summary>
+	public partial class RangeSlider : UserControl
+	{
+		const double ValueIndicatorSize = 12;
+		const double LabelFontSize = 9;
+		const int MajorTickLength = 5;
+		const int MinorTickLength = 3;
+
+		/// <summary>
+		/// The dependency property for the Minimum property
+		/// </summary>
+		public static readonly DependencyProperty MinimumProperty = DependencyProperty.Register(
+			"Minimum",
+			typeof(double),
+			typeof(RangeSlider),
+			new PropertyMetadata(0.0, RangeSlider.SliderPropertyChanged));
+
+		/// <summary>
+		/// The dependency property for the Maximum property
+		/// </summary>
+		public static readonly DependencyProperty MaximumProperty = DependencyProperty.Register(
+			"Maximum",
+			typeof(double),
+			typeof(RangeSlider),
+			new PropertyMetadata(1.0, RangeSlider.SliderPropertyChanged));
+
+		/// <summary>
+		/// The dependency property for the Value property
+		/// </summary>
+		public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
+			"Value",
+			typeof(double),
+			typeof(RangeSlider),
+			new FrameworkPropertyMetadata(
+				0.5,
+				FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+				RangeSlider.ValueChanged,
+				RangeSlider.CoerceValueCallback));
+
+		/// <summary>
+		/// The dependency property for the Value property
+		/// </summary>
+		public static readonly DependencyProperty MarkerValueProperty = DependencyProperty.Register(
+			"MarkerValue",
+			typeof(double),
+			typeof(RangeSlider),
+			new FrameworkPropertyMetadata(0.0, RangeSlider.MarkerValueChanged));
+
+		/// <summary>
+		/// The dependency property for the Value property
+		/// </summary>
+		public static readonly DependencyProperty LowerLimitProperty = DependencyProperty.Register(
+			"LowerLimit",
+			typeof(double),
+			typeof(RangeSlider),
+			new FrameworkPropertyMetadata(
+				0.25,
+				FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+				RangeSlider.LimitsChanged,
+				RangeSlider.CoerceValueCallback));
+
+		/// <summary>
+		/// The dependency property for the UpperLimit property
+		/// </summary>
+		public static readonly DependencyProperty UpperLimitProperty = DependencyProperty.Register(
+			"UpperLimit",
+			typeof(double),
+			typeof(RangeSlider),
+			new FrameworkPropertyMetadata(
+				0.75,
+				FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+				RangeSlider.LimitsChanged,
+				RangeSlider.CoerceValueCallback));
+
+		/// <summary>
+		/// The dependency property for the ShowLimits property
+		/// </summary>
+		public static readonly DependencyProperty ShowLimitsProperty = DependencyProperty.Register(
+			"ShowLimits",
+			typeof(bool),
+			typeof(RangeSlider),
+			new PropertyMetadata(false));
+
+		/// <summary>
+		/// The dependency property for the ShowLimits property
+		/// </summary>
+		public static readonly DependencyProperty OrientationProperty = DependencyProperty.Register(
+			"Orientation",
+			typeof(Orientation),
+			typeof(RangeSlider),
+			new PropertyMetadata(Orientation.Vertical));
+
+		/// <summary>
+		/// The dependency property for the TickStart property
+		/// </summary>
+		public static readonly DependencyProperty TickStartProperty = DependencyProperty.Register(
+			"TickStart",
+			typeof(double),
+			typeof(RangeSlider),
+			new PropertyMetadata(0.0, RangeSlider.SliderPropertyChanged));
+
+		/// <summary>
+		/// The dependency property for the TickEnd property
+		/// </summary>
+		public static readonly DependencyProperty TickEndProperty = DependencyProperty.Register(
+			"TickEnd",
+			typeof(double),
+			typeof(RangeSlider),
+			new PropertyMetadata(1.0, RangeSlider.SliderPropertyChanged));
+
+		/// <summary>
+		/// The dependency property for the TickMinorSpacing property
+		/// </summary>
+		public static readonly DependencyProperty TickMinorSpacingProperty = DependencyProperty.Register(
+			"TickMinorSpacing",
+			typeof(double),
+			typeof(RangeSlider),
+			new PropertyMetadata(0.05, RangeSlider.SliderPropertyChanged));
+
+		/// <summary>
+		/// The dependency property for the TickMajorSpacing property
+		/// </summary>
+		public static readonly DependencyProperty TickMajorSpacingProperty = DependencyProperty.Register(
+			"TickMajorSpacing",
+			typeof(double),
+			typeof(RangeSlider),
+			new PropertyMetadata(0.2, RangeSlider.SliderPropertyChanged));
+
+		/// <summary>
+		/// The dependency property for the TickLabels property
+		/// </summary>
+		public static readonly DependencyProperty TickLabelsProperty = DependencyProperty.Register(
+			"TickLabels",
+			typeof(string),
+			typeof(RangeSlider),
+			new PropertyMetadata(string.Empty, RangeSlider.SliderPropertyChanged));
+
+		/// <summary>
+		/// The dependency property for the AxisLabel property
+		/// </summary>
+		public static readonly DependencyProperty AxisLabelProperty = DependencyProperty.Register(
+			"AxisLabel",
+			typeof(string),
+			typeof(RangeSlider),
+			new PropertyMetadata(string.Empty));
+
+		/// <summary>
+		/// The set part Height property key (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyPropertyKey SliderPartHeightPropertyKey = DependencyProperty.RegisterReadOnly(
+			"SliderPartHeight",
+			typeof(GridLength),
+			typeof(RangeSlider),
+			new PropertyMetadata(new GridLength(1, GridUnitType.Star)));
+
+		/// <summary>
+		/// The set part Height property (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyProperty SliderPartHeightProperty = RangeSlider.SliderPartHeightPropertyKey.DependencyProperty;
+
+		/// <summary>
+		/// The set part Height property key (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyPropertyKey UpperPartHeightPropertyKey = DependencyProperty.RegisterReadOnly(
+			"UpperPartHeight",
+			typeof(GridLength),
+			typeof(RangeSlider),
+			new PropertyMetadata(new GridLength(1, GridUnitType.Star)));
+
+		/// <summary>
+		/// The set part Height property (read-only dependancy property)
+		/// </summary>
+		static readonly DependencyProperty UpperPartHeightProperty = RangeSlider.UpperPartHeightPropertyKey.DependencyProperty;
+
+		/// <summary>
+		/// The set part Height property key (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyPropertyKey LowerPartHeightPropertyKey = DependencyProperty.RegisterReadOnly(
+			"LowerPartHeight",
+			typeof(GridLength),
+			typeof(RangeSlider),
+			new PropertyMetadata(new GridLength(1, GridUnitType.Star)));
+
+
+		/// <summary>
+		/// The set part Height property (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyProperty LowerPartHeightProperty = RangeSlider.LowerPartHeightPropertyKey.DependencyProperty;
+
+		/// <summary>
+		/// The set part Y property key (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyPropertyKey ValueMarginPropertyKey = DependencyProperty.RegisterReadOnly(
+			"ValueMargin",
+			typeof(Thickness),
+			typeof(RangeSlider),
+			new PropertyMetadata(new Thickness()));
+
+		/// <summary>
+		/// The set part Height property (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyProperty ValueMarginProperty = RangeSlider.ValueMarginPropertyKey.DependencyProperty;
+
+
+		/// <summary>
+		/// The set part Y property key (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyPropertyKey MarkerValueMarginPropertyKey = DependencyProperty.RegisterReadOnly(
+			"MarkerValueMargin",
+			typeof(Thickness),
+			typeof(RangeSlider),
+			new PropertyMetadata(new Thickness()));
+
+		/// <summary>
+		/// The set part Height property (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyProperty MarkerValueMarginProperty = RangeSlider.MarkerValueMarginPropertyKey.DependencyProperty;
+
+
+		/// <summary>
+		/// The set part Height property key (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyPropertyKey SliderPartWidthPropertyKey = DependencyProperty.RegisterReadOnly(
+			"SliderPartWidth",
+			typeof(double),
+			typeof(RangeSlider),
+			new PropertyMetadata(20.0));
+
+		/// <summary>
+		/// The set part Height property (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyProperty SliderPartWidthProperty = RangeSlider.SliderPartWidthPropertyKey.DependencyProperty;
+
+		/// <summary>
+		/// The label row height property key (read-only dependancy property)
+		/// </summary>
+		private static readonly DependencyProperty LabelColumnSizeProperty = DependencyProperty.Register(
+			"LabelColumnSize",
+			typeof(double),
+			typeof(RangeSlider),
+			new PropertyMetadata(0.0, LabelSizeChanged));
+
+		private static void LabelSizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var slider = d as RangeSlider;
+			slider.CalculatePartHeights();
+		}
+
+		private readonly List<Tuple<double, string>> labelList = new List<Tuple<double, string>>();
+		private double rounder = 0.0;
+		private string stringFormat = "0.00";
+		private Color _majorTickColor = Colors.White;
+		private SolidColorBrush _majorTickBrush = Brushes.White;
+		private Color _minorTickColor = Colors.Gray;
+		private SolidColorBrush _minorTickBrush = Brushes.Gray;
+		private Color _tickLabelColor = Colors.White;
+		private SolidColorBrush _tickLabelBrush = Brushes.White;
+
+
+		private bool _draggingUpper = false;
+		private bool _draggingLower = false;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RangeSlider"/> class.
+		/// </summary>
+		public RangeSlider()
+		{
+			this.InitializeComponent();
+		}
+
+		/// <summary>
+		/// Gets or sets the tick start location. 
+		/// Minor ticks are drawn starting at this value, increasing by TickMinorSpacing until we are past TickEnd. 
+		/// Major ticks are drawn starting at this value, increasing by TickMajorSpacing until we are past TickEnd. 
+		/// Major ticks take precedence over minor ticks.
+		/// Only ticks that are within Minimum and Maximum (inclusive) are drawn.
+		/// </summary>
+		public double TickStart
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.TickStartProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.TickStartProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the tick end location. 
+		/// Minor ticks are drawn starting at TickStart, increasing by TickMinorSpacing until we are past this value. 
+		/// Major ticks are drawn starting at TickStart, increasing by TickMajorSpacing until we are past this value. 
+		/// Major ticks take precedence over minor ticks.
+		/// Only ticks that are within Minimum and Maximum (inclusive) are drawn.
+		/// </summary>
+		public double TickEnd
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.TickEndProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.TickEndProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the minor tick spacing. 
+		/// Minor ticks are drawn starting at TickStart, increasing by this value until we are past TickEnd. 
+		/// Only ticks that are within Minimum and Maximum (inclusive) are drawn.
+		/// </summary>
+		public double TickMinorSpacing
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.TickMinorSpacingProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.TickMinorSpacingProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the major tick spacing. 
+		/// Major ticks are drawn starting at TickStart, increasing by this value until we are past TickEnd. 
+		/// Only ticks that are within Minimum and Maximum (inclusive) are drawn.
+		/// </summary>
+		public double TickMajorSpacing
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.TickMajorSpacingProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.TickMajorSpacingProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the tick labels. This is a string with pipe-delimited labels. 
+		/// Each label should be either a number, or a number followed by a comma and a label.
+		/// If only a number is found the number is rendered at the location indicated by it.
+		/// If a label is also present, the label is rendered at the location indicated by the number.
+		/// </summary>
+		public string TickLabels
+		{
+			get
+			{
+				return (string)this.GetValue(RangeSlider.TickLabelsProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.TickLabelsProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the current value of the slider.
+		/// </summary>
+		public double Value
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.ValueProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.ValueProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the current value of the slider.
+		/// </summary>
+		public double MarkerValue
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.MarkerValueProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.MarkerValueProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the minimum value of the slider range.
+		/// </summary>
+		public double Minimum
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.MinimumProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.MinimumProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the maximum value of the slider range.
+		/// </summary>
+		public double Maximum
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.MaximumProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.MaximumProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		public bool ShowLimits
+		{
+			get
+			{
+				return (bool)this.GetValue(RangeSlider.ShowLimitsProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.ShowLimitsProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		public Orientation Orientation
+		{
+			get
+			{
+				return (Orientation)this.GetValue(RangeSlider.OrientationProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.OrientationProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the lower limit value of the slider range.
+		/// </summary>
+		public double LowerLimit
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.LowerLimitProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.LowerLimitProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the lower limit value of the slider range.
+		/// </summary>
+		public double UpperLimit
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.UpperLimitProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.UpperLimitProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the text of the AxisLabel displayed inside slider on the left.
+		/// </summary>
+		public string AxisLabel
+		{
+			get
+			{
+				return (string)this.GetValue(RangeSlider.AxisLabelProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.AxisLabelProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the minimum value of the slider range.
+		/// </summary>
+		private GridLength UpperPartHeight
+		{
+			get
+			{
+				return (GridLength)this.GetValue(RangeSlider.UpperPartHeightProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.UpperPartHeightProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the minimum value of the slider range.
+		/// </summary>
+		private GridLength LowerPartHeight
+		{
+			get
+			{
+				return (GridLength)this.GetValue(RangeSlider.LowerPartHeightProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.LowerPartHeightProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the minimum value of the slider range.
+		/// </summary>
+		private GridLength SliderPartHeight
+		{
+			get
+			{
+				return (GridLength)this.GetValue(RangeSlider.SliderPartHeightProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.SliderPartHeightProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the minimum value of the slider range.
+		/// </summary>
+		private Thickness ValueMargin
+		{
+			get
+			{
+				return (Thickness)this.GetValue(RangeSlider.ValueMarginProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.ValueMarginPropertyKey, value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the minimum value of the slider range.
+		/// </summary>
+		private Thickness MarkerValueMargin
+		{
+			get
+			{
+				return (Thickness)this.GetValue(RangeSlider.MarkerValueMarginProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.MarkerValueMarginPropertyKey, value);
+			}
+		}
+
+		bool IsHorizontal { get { return Orientation == Orientation.Horizontal; } }
+
+		bool IsVertical { get { return Orientation == Orientation.Vertical; } }
+
+		/// <summary>
+		/// Gets or sets the minimum value of the slider range.
+		/// </summary>
+		private double SliderPartWidth
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.SliderPartWidthProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.SliderPartWidthProperty, value);
+			}
+		}
+
+
+		/// <summary>
+		/// Gets or sets the minimum value of the slider range.
+		/// </summary>
+		public double LabelColumnSize
+		{
+			get
+			{
+				return (double)this.GetValue(RangeSlider.LabelColumnSizeProperty);
+			}
+			set
+			{
+				this.SetValue(RangeSlider.LabelColumnSizeProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// Called when the <see cref="E:System.Windows.FrameworkElement.SizeChanged" /> event is raised. Used to regenerate the ticks and labels.
+		/// </summary>
+		/// <param name="sizeInfo">Details of the old and new size involved in the change.</param>
+		protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
+		{
+			base.OnRenderSizeChanged(sizeInfo);
+			this.RecalculateLabelsAndTicks();
+		}
+
+		/// <summary>
+		/// Parses the labels property for the list of labels to render.
+		/// </summary>
+		private void ParseLabels()
+		{
+			var labelPairs = this.TickLabels.Split("|".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+			this.labelList.Clear();
+			foreach (var pair in labelPairs)
+			{
+				var label = pair.Split(",".ToCharArray());
+				var stringIndex = (label.Length == 1) ? 0 : 1;
+				double location;
+				if (double.TryParse(label[0], out location))
+				{
+					this.labelList.Add(Tuple.Create(location, label[stringIndex]));
+				}
+			}
+
+			LabelColumnSize = this.labelList.Any() ? 30 : 0;
+		}
+
+		private double UsableSize
+		{
+			get
+			{
+				return Orientation == Orientation.Vertical ? this.ActualHeight - ValueIndicatorSize : this.ActualWidth - ValueIndicatorSize;
+			}
+		}
+
+		/// <summary>
+		/// Calculates the widths of the set and unset parts of the slider.
+		/// </summary>
+		private void CalculatePartHeights()
+		{
+			double lowerPartHeight, sliderPartHeight, upperPartHeight, sliderPartWidth, valueYPos, markerValueYPos;
+			if (this.ActualHeight == 0)
+			{
+				sliderPartHeight = 1.0;
+				sliderPartWidth = 0;
+				lowerPartHeight = 0;
+				upperPartHeight = 0;
+				valueYPos = 0;
+				markerValueYPos = 0;
+			}
+			else
+			{
+				double lowerPos = GetLocation(this.LowerLimit);
+				double upperPos = GetLocation(this.UpperLimit);
+
+				if (IsVertical)
+				{
+					lowerPartHeight = this.UsableSize * (1.0 - lowerPos);
+					sliderPartHeight = this.UsableSize * (lowerPos - upperPos);
+					upperPartHeight = this.UsableSize * (upperPos);
+				}
+				else
+				{
+					lowerPartHeight = this.UsableSize * (lowerPos);
+					sliderPartHeight = this.UsableSize * (upperPos - lowerPos);
+					upperPartHeight = this.UsableSize * (1.0 - upperPos);
+				}
+
+				valueYPos = this.UsableSize * GetLocation(this.Value);
+				markerValueYPos = this.UsableSize * GetLocation(this.MarkerValue);
+
+				sliderPartWidth = (IsVertical ? this.ActualWidth : this.ActualHeight) - LabelColumnSize;
+			}
+
+			this.SetValue(RangeSlider.SliderPartHeightPropertyKey, new GridLength(sliderPartHeight, GridUnitType.Star));
+			this.SetValue(RangeSlider.UpperPartHeightPropertyKey, new GridLength(upperPartHeight, GridUnitType.Star));
+			this.SetValue(RangeSlider.LowerPartHeightPropertyKey, new GridLength(lowerPartHeight, GridUnitType.Star));
+			this.SetValue(RangeSlider.SliderPartWidthPropertyKey, sliderPartWidth);
+			this.SetValue(RangeSlider.ValueMarginPropertyKey, new Thickness(IsVertical ? 0 : valueYPos, IsVertical ? valueYPos : 0, 0, 0));
+			this.SetValue(RangeSlider.MarkerValueMarginPropertyKey, new Thickness(IsVertical ? 0 : markerValueYPos, IsVertical ? markerValueYPos : 0, 0, 0));
+		}
+
+		/// <summary>
+		/// Recalculates the label and tick lists.
+		/// </summary>
+		private void RecalculateLabelsAndTicks()
+		{
+			//this.TickCanvas.Children.Clear();
+			this.TickLabelCanvas.Children.Clear();
+
+			if ((this.TickStart != this.TickEnd) && (this.Minimum != this.Maximum))
+			{
+				var lines = new Dictionary<string, Line>();
+
+				this.InsertMinorTicks(lines);
+				this.InsertMajorTicks(lines);
+
+				// Now add the resulting list to the canvas.
+				foreach (Line line in lines.Values)
+				{
+					this.TickLabelCanvas.Children.Add(line);
+				}
+			}
+
+			// Check whether there are any labels to add to this control
+			if (this.labelList.Any() && (this.Minimum != this.Maximum))
+			{
+				this.InsertTickLabels();
+			}
+
+			// Update the slider position.
+			this.CalculatePartHeights();
+		}
+
+		internal double GetLocation(double pos)
+		{
+			double location = (pos - this.Minimum) / (this.Maximum - this.Minimum);
+			if (Orientation == Orientation.Vertical)
+			{
+				location = 1.0 - location;
+			}
+			return location;
+		}
+
+		/// <summary>
+		/// Adds the tick labels to the canvas of the control.
+		/// </summary>
+		private void InsertTickLabels()
+		{
+			foreach (var label in this.labelList)
+			{
+				var textBlock = new TextBlock
+				{
+					Text = label.Item2,
+					FontSize = LabelFontSize,
+					Foreground = _tickLabelBrush,
+					Background = Brushes.Transparent,
+					HorizontalAlignment = IsVertical ? HorizontalAlignment.Right : HorizontalAlignment.Center,
+					VerticalAlignment = IsVertical ? VerticalAlignment.Center : VerticalAlignment.Bottom,
+					Margin = new Thickness(0.0),
+					Height = ValueIndicatorSize
+				};
+
+				// Calculate the normalized (0..1) horizontal location of the label (which is centered below this)
+				double location = GetLocation(label.Item1);
+
+				// Scale to the actual width of the grid, but place it 1.5pixels inside the range..
+				location = location * (this.UsableSize - 1);
+
+				this.TickLabelCanvas.Children.Add(textBlock);
+
+				// Now position the label accordingly
+				if (IsVertical)
+				{
+					textBlock.SetValue(Canvas.TopProperty, location);
+					textBlock.SetValue(Canvas.RightProperty, 2.0 + MajorTickLength);
+				}
+				else
+				{
+					textBlock.SetValue(Canvas.LeftProperty, location + (LabelFontSize/3) - ((label.Item2.Length-1) * 0.75 * (LabelFontSize/3)));
+					textBlock.SetValue(Canvas.BottomProperty, 2.0 + MajorTickLength);
+				}
+			}
+
+			var rotate90CCW = new RotateTransform(IsVertical ? -90 : 0);
+
+			var axisLabelBlock = new TextBlock()
+			{
+				Text = AxisLabel,
+				FontSize = LabelFontSize * 1.5,
+				Foreground = _tickLabelBrush,
+				Background = Brushes.Transparent,
+				HorizontalAlignment = HorizontalAlignment.Center,
+				VerticalAlignment = VerticalAlignment.Center,
+				Margin = new Thickness(0.0),
+				RenderTransformOrigin = new Point(1.0, 0.5),
+				RenderTransform = rotate90CCW,
+			};
+
+			this.TickLabelCanvas.Children.Add(axisLabelBlock);
+			if (IsVertical)
+			{
+				axisLabelBlock.SetValue(Canvas.TopProperty, (this.ActualHeight / 2) - (AxisLabel.Length * 0.4 * LabelFontSize));
+				axisLabelBlock.SetValue(Canvas.RightProperty, axisLabelBlock.FontSize + 9.0 + MajorTickLength);
+			}
+			else
+			{
+				axisLabelBlock.SetValue(Canvas.LeftProperty, (this.ActualWidth / 2) - (AxisLabel.Length * 0.4 * LabelFontSize));
+				axisLabelBlock.SetValue(Canvas.BottomProperty, axisLabelBlock.FontSize + 5.0 + MajorTickLength);
+			}
+
+		}
+
+		/// <summary>
+		/// Inserts the minor ticks into the given dictionary. The key for this dictionary is the string representation
+		/// of the location on the axis. This is used to make sure major ticks overwrite minor ticks and don't
+		/// introduce floating point errors when comparing.
+		/// </summary>
+		/// <param name="lines">The dictionary containing the minor and major tick lines.</param>
+		private void InsertMinorTicks(Dictionary<string, Line> lines)
+		{
+			// Minor tick lines
+			if (this.TickMinorSpacing > 0)
+			{
+				for (double start = this.TickStart; start <= this.TickEnd; start += this.TickMinorSpacing)
+				{
+					var key = start.ToString(this.stringFormat);
+					var location = GetLocation(start);
+					if ((location >= 0.0) && (location <= 1.0))
+					{
+						// We scale the axis so that the minimum and maximum are just inside the control.
+						location = location * (this.UsableSize - 1) + ValueIndicatorSize / 2;
+						Line line = new Line
+						{
+							Y1 = IsVertical ? location : LabelColumnSize,
+							Y2 = IsVertical ? location : LabelColumnSize - MinorTickLength,
+							X1 = IsVertical ? LabelColumnSize : location,
+							X2 = IsVertical ? LabelColumnSize - MinorTickLength : location,
+							Stroke = _minorTickBrush,
+							SnapsToDevicePixels = true
+						};
+						lines[key] = line;
+
+					}
+				}
+			}
+		}
+
+
+		/// <summary>
+		/// Inserts the major ticks into the given dictionary. The key for this dictionary is the string representation
+		/// of the location on the axis. This is used to make sure major ticks overwrite minor ticks and don't
+		/// introduce floating point errors when comparing.
+		/// </summary>
+		/// <param name="lines">The dictionary containing the minor and major tick lines.</param>
+		private void InsertMajorTicks(Dictionary<string, Line> lines)
+		{
+			if (this.TickMajorSpacing > 0)
+			{
+				for (double start = this.TickStart; start <= this.TickEnd; start += this.TickMajorSpacing)
+				{
+					var key = start.ToString(this.stringFormat);
+					double location = GetLocation(start);
+					if ((location >= 0.0) && (location <= 1.0))
+					{
+						// We scale the axis so that the minimum and maximum are just inside the control.
+						location = location * (this.UsableSize - 1) + ValueIndicatorSize / 2;
+						Line line = new Line
+						{
+							Y1 = IsVertical ? location : LabelColumnSize,
+							Y2 = IsVertical ? location : LabelColumnSize - MajorTickLength,
+							X1 = IsVertical ? LabelColumnSize : location,
+							X2 = IsVertical ? LabelColumnSize - MajorTickLength : location,
+							Stroke = _majorTickBrush,
+							SnapsToDevicePixels = true
+						};
+
+						lines[key] = line;
+					}
+				}
+			}
+		}
+
+		public Color MajorTickColor
+		{
+			get { return _majorTickColor; }
+			set
+			{
+				if (value != _majorTickColor)
+				{
+					_majorTickColor = value;
+					_majorTickBrush = new SolidColorBrush(_majorTickColor);
+				}
+			}
+		}
+
+		public Color MinorTickColor
+		{
+			get { return _minorTickColor; }
+			set
+			{
+				if (value != _minorTickColor)
+				{
+					_minorTickColor = value;
+					_minorTickBrush = new SolidColorBrush(_minorTickColor);
+				}
+			}
+		}
+
+		public Color TickLabelColor
+		{
+			get { return _tickLabelColor; }
+			set
+			{
+				if (value != _tickLabelColor)
+				{
+					_tickLabelColor = value;
+					_tickLabelBrush = new SolidColorBrush(_tickLabelColor);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Called by the dependency property when any of the slider properties have changed.
+		/// </summary>
+		/// <param name="obj">The slider object that caused the change.</param>
+		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.</param>
+		private static void SliderPropertyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+		{
+			bool callLabelRecalc = true;
+			RangeSlider slider = obj as RangeSlider;
+
+			switch (e.Property.Name)
+			{
+				case "Maximum":
+				case "Minimum":
+				case "TickStart":
+				case "TickEnd":
+				case "TickMinorSpacing":
+				case "TickMajorSpacing":
+					// No extra processing neccessary
+					break;
+
+				case "TickLabels":
+					slider.ParseLabels();
+					break;
+
+				default:
+					callLabelRecalc = false;
+					break;
+			}
+
+			if (callLabelRecalc)
+			{
+				slider.RecalculateLabelsAndTicks();
+			}
+
+		}
+
+		/// <summary>
+		/// Called by the dependency property when the Value has changed.
+		/// </summary>
+		/// <param name="obj">The object.</param>
+		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.</param>
+		private static void ValueChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+		{
+			RangeSlider slider = obj as RangeSlider;
+			if (slider == null)
+			{
+				return;
+			}
+			if (slider.ActualHeight > 0)
+			{
+				double valueYPos = slider.UsableSize * slider.GetLocation(slider.Value);
+				slider.SetValue(RangeSlider.ValueMarginPropertyKey, new Thickness(slider.IsVertical ? 0 : valueYPos, slider.IsVertical ? valueYPos : 0, 0, 0));
+			}
+		}
+
+		/// <summary>
+		/// Called by the dependency property when the Value has changed.
+		/// </summary>
+		/// <param name="obj">The object.</param>
+		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.</param>
+		private static void MarkerValueChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+		{
+			RangeSlider slider = obj as RangeSlider;
+			if (slider == null)
+			{
+				return;
+			}
+			if (slider.ActualHeight > 0)
+			{
+				double markerValueYPos = slider.UsableSize * slider.GetLocation(slider.MarkerValue);
+				slider.SetValue(RangeSlider.MarkerValueMarginPropertyKey, new Thickness(slider.IsVertical ? 0 : markerValueYPos, slider.IsVertical ? markerValueYPos : 0, 0, 0));
+			}
+		}
+
+		/// <summary>
+		/// Called by the dependency property when the Value has changed.
+		/// </summary>
+		/// <param name="obj">The object.</param>
+		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.</param>
+		private static void LimitsChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+		{
+			RangeSlider slider = obj as RangeSlider;
+			if (slider == null)
+			{
+				return;
+			}
+
+			slider.CalculatePartHeights();
+		}
+
+		/// <summary>
+		/// Coerces the given value to a valid range.
+		/// </summary>
+		/// <param name="dependencyObject">The dependency object.</param>
+		/// <param name="baseValue">The base value.</param>
+		/// <returns></returns>
+		private static object CoerceValueCallback(DependencyObject dependencyObject, object baseValue)
+		{
+			RangeSlider slider = dependencyObject as RangeSlider;
+			if (slider == null)
+			{
+				return null;
+			}
+
+			var newVal = (double)baseValue;
+
+			// Check if we need to round it
+			if (slider.rounder != 0.0)
+			{
+				newVal = Math.Round(slider.rounder * newVal) / slider.rounder;
+			}
+
+			// Make sure it's within our defined range
+			newVal = Math.Min(Math.Max(slider.Minimum, newVal), slider.Maximum);
+
+			return newVal;
+		}
+
+		Grid MainGrid { get { return Orientation == Orientation.Vertical ? this.MainVGrid : this.MainHGrid; } }
+		Canvas TickLabelCanvas { get { return Orientation == Orientation.Vertical ? this.TickLabelVCanvas : this.TickLabelHCanvas; } }
+
+		/// <summary>
+		/// Handles the OnMouseButtonDown event of the MainGrid control. Captures the mouse and sets the current 
+		/// value to the click point. If the textbox currently is active, it is made inactive.
+		/// </summary>
+		/// <param name="sender">The source of the event.</param>
+		/// <param name="e">The <see cref="MouseButtonEventArgs"/> instance containing the event data.</param>
+		private void MainGrid_OnMouseButtonDown(object sender, MouseButtonEventArgs e)
+		{
+			if ((e.LeftButton == MouseButtonState.Pressed) && ShowLimits)
+			{
+				Point pt = e.GetPosition(this.MainGrid);
+
+				double cursorPos = IsVertical ? pt.Y - (ValueIndicatorSize / 2) : pt.X - (ValueIndicatorSize / 2);
+				double lowerPos = this.UsableSize * GetLocation(this.LowerLimit);
+				double upperPos = this.UsableSize * GetLocation(this.UpperLimit);
+
+				if (Math.Abs(cursorPos - upperPos) < 6)
+				{
+					_draggingUpper = true;
+					_draggingLower = false;
+					this.MainGrid.CaptureMouse();
+				}
+				else if (Math.Abs(cursorPos - lowerPos) < 6)
+				{
+					_draggingUpper = false;
+					_draggingLower = true;
+					this.MainGrid.CaptureMouse();
+				}
+				e.Handled = true;
+			}
+		}
+
+		/// <summary>
+		/// Sets the value from mouse location.
+		/// </summary>
+		/// <param name="e">The <see cref="MouseEventArgs"/> instance containing the event data.</param>
+		private void SetValueFromMouse(MouseEventArgs e)
+		{
+			Point pt = e.GetPosition(this.MainGrid);
+			double normalized = 1.0;
+			double clickValue = 0;
+
+			if (IsVertical)
+			{
+				normalized = 1.0 * (pt.Y - ValueIndicatorSize / 2) / (this.UsableSize - 1);
+				clickValue = this.Maximum - (float)Math.Min(1.0, Math.Max(0, normalized)) * (this.Maximum - this.Minimum);
+			}
+			else
+			{
+				normalized = 1.0 * (pt.X - ValueIndicatorSize / 2) / (this.UsableSize - 1);
+				clickValue = this.Minimum + (float)Math.Min(1.0, Math.Max(0, normalized)) * (this.Maximum - this.Minimum);
+			}
+
+			if (_draggingUpper)
+			{
+				this.UpperLimit = Math.Max(clickValue, this.LowerLimit);
+			}
+			else if (_draggingLower)
+			{
+				this.LowerLimit = Math.Min(clickValue, this.UpperLimit);
+			}
+		}
+
+		/// <summary>
+		/// Handles the OnMouseButtonUp event of the MainGrid control.
+		/// </summary>
+		/// <param name="sender">The source of the event.</param>
+		/// <param name="e">The <see cref="MouseButtonEventArgs"/> instance containing the event data.</param>
+		private void MainGrid_OnMouseButtonUp(object sender, MouseButtonEventArgs e)
+		{
+			this.MainGrid.ReleaseMouseCapture();
+		}
+
+		/// <summary>
+		/// Handles the OnMouseMove event of the MainGrid control.
+		/// </summary>
+		/// <param name="sender">The source of the event.</param>
+		/// <param name="e">The <see cref="MouseEventArgs"/> instance containing the event data.</param>
+		private void MainGrid_OnMouseMove(object sender, MouseEventArgs e)
+		{
+			if (this.MainGrid.IsMouseCaptured)
+			{
+				this.SetValueFromMouse(e);
+			}
+		}
+
+		/// <summary>
+		/// Handles the OnSizeChanged event of the control.
+		/// </summary>
+		/// <param name="sender">The source of the event.</param>
+		/// <param name="e">The <see cref="SizeChangedEventArgs"/> instance containing the event data.</param>
+		private void TrackPart_OnSizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			this.RecalculateLabelsAndTicks();
+		}
+	}
+}

--- a/OATControl/Converters/DoubleDividerConverter.cs
+++ b/OATControl/Converters/DoubleDividerConverter.cs
@@ -45,15 +45,19 @@ namespace OATControl.Converters
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            double len = 1;
             if (value is double)
             {
                 if (Inverter != 0)
 				{
-                    return new GridLength((Inverter-(double)value) / Divisor, GridUnitType.Star);
+                    len=(Inverter-(double)value) / Divisor;
                 }
-                return new GridLength((double)value / Divisor, GridUnitType.Star);
+				else
+				{
+                    len = (double)value / Divisor;
+                }
             }
-            return new GridLength(10);
+            return new GridLength(len, GridUnitType.Star);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/OATControl/Converters/IntToVisibilityConverter.cs
+++ b/OATControl/Converters/IntToVisibilityConverter.cs
@@ -31,7 +31,7 @@ namespace OATControl.Converters
         /// </returns>
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            long val = (long)value;
+            long val = value is long ? (long)value : (long)(int)value;
             Visibility visualState = UseCollapse ? Visibility.Collapsed : Visibility.Hidden;
             if (Operator.Equals(">"))
             {

--- a/OATControl/Converters/OrientationToVisibilityConverter.cs
+++ b/OATControl/Converters/OrientationToVisibilityConverter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace OATControl.Converters
+{
+    /// <summary>
+    /// Data binding helper.
+    /// Converts a binding to boolean to a Visibility value.
+    /// Returns Visibility.Hidden by default when bound value is false.
+    /// If Collapse property is true, returns Visibility.Collapsed when bound value is false.
+    /// Useful for binding Visibility property to a RadioButton.IsChecked property.
+    /// </summary>
+    public class OrientationToVisibilityConverter : MarkupExtension, IValueConverter
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether a false source value is converted to Collapsed or Hidden.
+        /// </summary>
+        public bool Collapse { get; set; }
+        public Orientation VisibleOrientation  { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            Visibility v = Visibility.Visible;
+
+            if (this.VisibleOrientation != (Orientation)value)
+            {
+                v = this.Collapse ? Visibility.Collapsed : Visibility.Hidden;
+            }
+
+            return v;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}

--- a/OATControl/Converters/StringToVisibilityConverter.cs
+++ b/OATControl/Converters/StringToVisibilityConverter.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace OATControl.Converters
+{
+	/// <summary>
+	/// Data binding helper.
+	/// Converts a binding from boolean to an integer value.
+	/// Returns FalseValue when bound value is false and TrueValue when value is ture.
+	/// </summary>
+	public class StringToVisibilityConverter : MarkupExtension, IValueConverter
+	{
+		/// <summary>
+		/// Gets or sets the integer value to return on the given boolean value.
+		/// </summary>
+		public Visibility EqualState { get; set; }
+
+		/// <summary>
+		/// Converts a value.
+		/// </summary>
+		/// <param name="value">The value produced by the binding source.</param>
+		/// <param name="targetType">The type of the binding target property.</param>
+		/// <param name="parameter">The converter parameter to use.</param>
+		/// <param name="culture">The culture to use in the converter.</param>
+		/// <returns>
+		/// A converted value. If the method returns null, the valid null value is used.
+		/// </returns>
+		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		{
+			string val = value as string;
+			Visibility visualState;
+
+			if (val.Equals(parameter as string))
+			{
+				visualState = EqualState;
+			}
+			else
+			{
+				if ((EqualState==Visibility.Hidden) || (EqualState == Visibility.Collapsed))
+				{
+					visualState = Visibility.Visible;
+				}
+				else
+				{
+					visualState = Visibility.Collapsed;
+				}
+			}
+
+			return visualState;
+		}
+
+		/// <summary>
+		/// Converts a value back. Not implemented
+		/// </summary>
+		/// <param name="value">The value that is produced by the binding target.</param>
+		/// <param name="targetType">The type to convert to.</param>
+		/// <param name="parameter">The converter parameter to use.</param>
+		/// <param name="culture">The culture to use in the converter.</param>
+		/// <returns>
+		/// A converted value. If the method returns null, the valid null value is used.
+		/// </returns>
+		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		{
+			return null;
+		}
+
+		/// <summary>
+		/// When implemented in a derived class, returns an object that is provided as the value of the target property for this markup extension.
+		/// </summary>
+		/// <param name="serviceProvider">A service provider helper that can provide services for the markup extension.</param>
+		/// <returns>
+		/// The object value to set on the property where the extension is applied.
+		/// </returns>
+		public override object ProvideValue(IServiceProvider serviceProvider)
+		{
+			return this;
+		}
+	}
+}

--- a/OATControl/DlgChooseOat.xaml
+++ b/OATControl/DlgChooseOat.xaml
@@ -28,7 +28,7 @@
 			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
-			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto"/>
 			<RowDefinition Height="Auto"/>
 			<RowDefinition Height="Auto"/>
 			<RowDefinition Height="Auto"/>
@@ -63,6 +63,10 @@
 				</DataTemplate>
 			</ListBox.ItemTemplate>
 		</ListBox>
+
+		<TextBlock Grid.Row="1" Grid.Column="0"  Text="Baud rate" Foreground="{StaticResource AccentSelectedColorBrush}" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,16,16,0" Visibility="{Binding ShowBaudRate,Converter={StaticResource CollapseOnFalse}}"/>
+		<ComboBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="1" Margin="8,20,0,0" ItemsSource="{Binding AvailableBaudRates}" SelectedValue="{Binding SelectedBaudRate}"
+					  Width="120" FontSize="16" HorizontalAlignment="Left" Foreground="Red" FontWeight="Bold" BorderBrush="#FF880000" Visibility="{Binding ShowBaudRate,Converter={StaticResource CollapseOnFalse}}"/>
 
 		<TextBlock Grid.Row="2" Grid.Column="0" Text="Pitch Level:" HorizontalAlignment="Right" Margin="0,20,9,11" Foreground="{StaticResource AccentSelectedColorBrush}" Visibility="{Binding ShowLevelDisplay, Converter={StaticResource CollapseOnFalse}}" />
 		<local:LevelDisplay Grid.Row="2" Grid.Column="1" Value="{Binding PitchOffset}" Range="3" Labels="-3|-2|-1|0|1|2|3" Margin="10,24,20,6" Visibility="{Binding ShowLevelDisplay, Converter={StaticResource CollapseOnFalse}}" />

--- a/OATControl/DlgRunPolarAlignment.xaml.cs
+++ b/OATControl/DlgRunPolarAlignment.xaml.cs
@@ -47,7 +47,7 @@ namespace OATControl
 				if (_state == 2)
 				{
 					// Move RA to Polaris
-					await SendCommandAsync($":Sr02:58:51#,n");
+					await SendCommandAsync($":Sr02:59:09#,n");
 
 					// Move DEC to twice Polaris Dec
 					if (Settings.Default.SiteLatitude > 0) // Northern hemisphere
@@ -65,18 +65,18 @@ namespace OATControl
 					// Sync the mount to Polaris coordinates
 					if (Settings.Default.SiteLatitude > 0) // Northern hemisphere
 					{
-						await SendCommandAsync($":SY+89*21:06.02:58:51#,n");
+						await SendCommandAsync($":SY+89*21:06.02:59:09#,n");
 					}
 					else
 					{
-						await SendCommandAsync($":SY-89*21:06.02:58:51#,n");
+						await SendCommandAsync($":SY-89*21:06.02:59:09#,n");
 					}
 				}
 			});
 
 			this.DataContext = this;
-			InitializeComponent();
 			State = 1;
+			InitializeComponent();
 		}
 
 		private async Task<bool> SendCommandAsync(string command)

--- a/OATControl/MainWindow.xaml
+++ b/OATControl/MainWindow.xaml
@@ -8,7 +8,7 @@
 		xmlns:controls="clr-namespace:OATControl.Controls" 
 		xmlns:converters="clr-namespace:OATControl.Converters"
 		mc:Ignorable="d"
-		Title="{Binding Version, StringFormat={} OpenAstroTracker Control V{0}}" MinHeight="705" MinWidth="720" Height="705" Width="720">
+		Title="{Binding Version, StringFormat={} OpenAstroTracker Control V{0}}" MinHeight="767" MinWidth="720" Height="767" Width="720">
 	<Window.Resources>
 		<converters:BoolToStringConverter x:Key="SlewModeConverter" TrueString="Pulsed" FalseString="Continuous" />
 		<converters:BoolToVisibilityConverter x:Key="TrueBoolToHidden" Collapse="False" IsReversed="True"/>
@@ -69,21 +69,6 @@
 			<Setter Property="Foreground" Value="#FF201010" />
 			<Setter Property="FontWeight" Value="Bold" />
 			<Setter Property="FontSize" Value="14" />
-			<!--<Style.Triggers>
-				<DataTrigger Binding="{Binding}" Value="True">
-					<Setter Property="Foreground" Value="Purple" />
-					<Setter TargetName="border" Property="Background" Value="{StaticResource AccentColorBrush3}" />
-				</DataTrigger>
-				<Trigger Property="IsChecked" Value="True">
-					<Setter Property="Foreground" Value="Blue" />
-					<Setter Property="Background" Value="{StaticResource HighlightBrush}" />
-					<Setter TargetName="border" Property="Background" Value="{StaticResource HighlightBrush}" />
-				</Trigger>
-				<Trigger Property="IsMouseOver" Value="True">
-					<Setter Property="Foreground" Value="Blue" />
-					<Setter Property="Background" Value="Yellow" />
-				</Trigger>
-			</Style.Triggers>-->
 			<Setter Property="Template">
 				<Setter.Value>
 					<ControlTemplate TargetType="ToggleButton">
@@ -230,18 +215,12 @@
 			<controls:PushButton Grid.Row="6" Grid.Column="3" Style="{StaticResource ArrowStyle}" Direction="S" IsEnabled="{Binding MountConnected}" Command="{Binding StartChangingCommand}" CommandParameter="DM-" />
 			<controls:PushButton Grid.Row="6" Grid.Column="5" Style="{StaticResource ArrowStyle}" Direction="S" IsEnabled="{Binding MountConnected}" Command="{Binding StartChangingCommand}" CommandParameter="DS-" />
 
-			<!--<TextBlock Grid.Row="7" Grid.Column="0"  Text="Preset" Margin="0,20,0,0" Style="{StaticResource TextBlockHeading}"  />-->
-
 			<Button Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="5" Content="Choose Target..." MinWidth="50" Margin="2,20,2,0" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding ChooseTargetCommand}" />
 			<TextBlock Grid.Row="7" Grid.Column="6" Grid.ColumnSpan="5" Text="{Binding SelectedPointOfInterest.Name}" MinWidth="50" Margin="2,20,2,0" Style="{StaticResource TextBlockLabelSmall}" HorizontalAlignment="Left"/>
-			
-			<!--<ComboBox Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="7"  Text="Preset" Margin="0,20,0,0" ItemsSource="{Binding AvailablePointsOfInterest}" DisplayMemberPath="Name" SelectedIndex="{Binding SelectedPointOfInterest}"
-					  FontSize="16" FontWeight="Bold" BorderBrush="#FF880000"/>-->
 
 			<Button Grid.Row="1" Grid.Column="7" Grid.RowSpan="1" Margin="8,0,8,4" Padding="0,4,0,8"  Content="&lt;- Sync" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding SyncToCurrentCommand}" />
 			<Button Grid.Row="2" Grid.Column="7" Grid.RowSpan="4" Margin="8,0" Padding="30,20"  Content="Slew!" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding SlewToTargetCommand}" />
 			<Button Grid.Row="6" Grid.Column="7" Grid.RowSpan="1" Margin="8,4,8,0" Padding="0,4,0,8"  Content="Sync -&gt;" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding SyncToTargetCommand}" />
-
 
 			<TextBlock Grid.Row="0" Grid.Column="8" Grid.ColumnSpan="7"  Text="Current" Style="{StaticResource TextBlockTitle}" HorizontalAlignment="Center"/>
 
@@ -321,14 +300,14 @@
 					<RowDefinition Height="Auto" />
 					<RowDefinition Height="Auto" />
 					<RowDefinition Height="*" />
-					<RowDefinition Height="Auto" />
+					<RowDefinition Height="60" />
 				</Grid.RowDefinitions>
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="*" />
 					<ColumnDefinition Width="Auto" />
 					<ColumnDefinition Width="Auto" />
 					<ColumnDefinition Width="Auto" />
-					<ColumnDefinition />
+					<ColumnDefinition Width="50"/>
 				</Grid.ColumnDefinitions>
 
 				<controls:PushButton Grid.Column="1" Grid.Row="1" Width="90" Height="90" Direction="W" IsEnabled="{Binding MountConnected}" Command="{Binding StartSlewingCommand}" CommandParameter="W" />
@@ -344,6 +323,50 @@
 					</StackPanel>
 					<Button  Height="26" HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="0,2,2,0" Content="Set Home" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding SetHomeCommand}" />
 				</StackPanel>
+				
+				<controls:RangeSlider Grid.Column="4" Grid.RowSpan="4" 
+						Width="48"
+						Height="270"
+						LabelColumnSize="30"
+						Minimum="{Binding DECStepperMinimum}"
+						Maximum="{Binding DECStepperMaximum}"
+						LowerLimit="{Binding DECStepperLowerLimit}"
+						UpperLimit="{Binding DECStepperUpperLimit}"
+						Value="{Binding DECStepperDegrees, Mode=OneWay}" 
+						MarkerValue="{Binding DECStepperTargetDegrees, Mode=OneWay}" 
+						Padding="0" 
+						ShowLimits="{Binding ElementName=ShowLimits,Path=IsChecked}"
+						AxisLabel="DEC Axis" 
+						TickMajorSpacing="30" 
+						TickMinorSpacing="10" 
+						TickStart="-90" 
+						TickEnd="180"
+						TickLabels="-90,0|-60,30|-30,60|0,90|30,60|60,30|90,0|120,-30|150,-60|180,-90"
+						MajorTickColor="#FC11"
+						MinorTickColor="#F911"
+						TickLabelColor="#FB11"
+				  />
+
+				<controls:RangeSlider Grid.Column="0" Grid.ColumnSpan="5" Grid.Row="5"
+						Height="48"
+						Orientation="Horizontal"
+						LabelColumnSize="22"
+						Minimum="{Binding RAStepperMinimum}"
+						Maximum="{Binding RAStepperMaximum}"
+						Value="{Binding RAStepperHours, Mode=OneWay}" 
+						MarkerValue="{Binding RAStepperTargetHours, Mode=OneWay}" 
+						Padding="0" 
+						ShowLimits="False"
+						AxisLabel="RA Axis" 
+						TickMajorSpacing="1" 
+						TickMinorSpacing="0.25" 
+						TickStart="-7"
+						TickEnd="7"
+						TickLabels="-6|-3|-1|0|1|3|6"
+						MajorTickColor="#FC11"
+						MinorTickColor="#F911"
+						TickLabelColor="#FB11"
+				  />
 
 			</Grid>
 			<Grid Grid.Row="0" Grid.Column="0" Visibility="{Binding IsCoarseSlewing, Converter={StaticResource TrueBoolToHidden}}">
@@ -525,14 +548,14 @@
 				<TextBlock Grid.Row="1" Grid.Column="2" MinWidth="64" Text="{Binding RAStepper}"  Style="{StaticResource TextBlockLabelValue}" TextAlignment="Center" />
 
 				<TextBlock Grid.Row="2" Grid.Column="1" Text="DEC Stepper"  Style="{StaticResource TextBlockLabelSmall}"/>
-				<TextBlock Grid.Row="2" Grid.Column="2" MinWidth="64" Text="{Binding DECStepper}"  Style="{StaticResource TextBlockLabelValue}" TextAlignment="Center" />
+				<TextBlock Grid.Row="2" Grid.Column="2" MinWidth="64" Text="{Binding DECStepper}"  Style="{StaticResource TextBlockLabelValue}" TextAlignment="Center" MouseRightButtonUp="OnDecMouseRightButtonUp"/>
 
 				<TextBlock Grid.Row="3" Grid.Column="1" Text="TRK Stepper"  Style="{StaticResource TextBlockLabelSmall}"/>
 				<TextBlock Grid.Row="3" Grid.Column="2" MinWidth="64" Text="{Binding TrkStepper}"  Style="{StaticResource TextBlockLabelValue}" TextAlignment="Center" />
 			</Grid>
 
 			<TextBlock Grid.Column="0" Grid.Row="1" Text="Tracking" Margin="0,5,0,1"  Style="{StaticResource TextBlockHeading}" />
-			<Controls:ToggleSwitchButton  Grid.Column="1" Grid.Row="1"  Margin="0,6,0,0" VerticalAlignment="Center" IsEnabled="{Binding MountConnected}" IsChecked="{Binding IsTracking}"/>
+			<Controls:ToggleSwitchButton  Grid.Column="1" Grid.Row="1"  Margin="0,6,0,0" VerticalAlignment="Center" IsEnabled="{Binding MountConnected}" IsChecked="{Binding IsTracking}" ThumbIndicatorBrush="#E00" />
 			<Grid Grid.Row="1" Grid.Column="2" Visibility="{Binding MountConnected, Converter={StaticResource bool2VisibilityConverter}}">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="*" />
@@ -553,6 +576,12 @@
 				<TextBlock Grid.Column="2" Text="On" FontSize="10" Margin="0,-4,0,0" FontWeight="Bold" />
 			</Grid>
 
+			<Button Grid.Row="2" Grid.Column="0" Content="Set Low" Height="22" Margin="6,2,0,2" HorizontalAlignment="Left" Padding="15,0" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding SetDecLowerLimitCommand}" Visibility="{Binding ElementName=ShowLimits, Path=IsChecked,Converter={StaticResource TrueBoolToVisible}}"/>
+
+			<TextBlock Grid.Column="0" Grid.Row="3" Text="Show Limits" Margin="0,5,0,1"  Style="{StaticResource TextBlockLabelSmall}" />
+			<Controls:ToggleSwitchButton Grid.Row="3" Grid.Column="1" Margin="0,2" IsEnabled="{Binding MountConnected}" Name="ShowLimits" ThumbIndicatorBrush="#E00" IsChecked="{Binding ShowDECLimits}"/>
+
+			
 			<Button Grid.Row="3" Grid.Column="2" Content="Mini-Control" Margin="0,2" HorizontalAlignment="Right" Padding="15,0" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding ShowMiniControllerCommand}" />
 			<Button Grid.Row="4" Grid.Column="2" Content="Settings" Margin="0,2" HorizontalAlignment="Right" Padding="15,0" IsEnabled="{Binding MountConnected}" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding ShowSettingsCommand}"/>
 			<Button Grid.Row="5" Grid.Column="2" Content="Log Files" Margin="0,2" HorizontalAlignment="Right" Padding="15,0" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding ShowLogFolderCommand}" />

--- a/OATControl/MainWindow.xaml.cs
+++ b/OATControl/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using System.Xml;
 
 namespace OATControl
 {
@@ -83,6 +84,11 @@ namespace OATControl
 					mountVm.OnAdjustTarget(command);
 				}
 			}
+		}
+
+		private void OnDecMouseRightButtonUp(object sender, MouseButtonEventArgs e)
+		{
+			mountVm.SetDecLowLimit();
 		}
 	}
 }

--- a/OATControl/MiniController.xaml.cs
+++ b/OATControl/MiniController.xaml.cs
@@ -1,6 +1,8 @@
-﻿using OATControl.ViewModels;
+﻿using OATControl.Properties;
+using OATControl.ViewModels;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -51,6 +53,11 @@ namespace OATControl
 			base.OnKeyDown(e);
 		}
 
+		protected override void OnClosing(CancelEventArgs e)
+		{
+			Settings.Default.MiniControllerPos = new System.Drawing.Point((int)this.Left, (int)this.Top);
+			base.OnClosing(e);
+		}
 		protected override void OnKeyUp(KeyEventArgs e)
 		{
 			string cmdParam = string.Empty;

--- a/OATControl/OATControl.csproj
+++ b/OATControl/OATControl.csproj
@@ -74,6 +74,9 @@
     <Compile Include="Controls\Joystick.xaml.cs">
       <DependentUpon>Joystick.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\RangeSlider.xaml.cs">
+      <DependentUpon>RangeSlider.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\ScopeCircles.cs" />
     <Compile Include="Controls\Arrow.cs" />
     <Compile Include="Controls\ScopePointer.cs" />
@@ -83,9 +86,11 @@
     <Compile Include="Converters\BoolToVisibilityConverter.cs" />
     <Compile Include="Converters\DoubleToHMSConverter.cs" />
     <Compile Include="Converters\DoubleDividerConverter.cs" />
-    <Compile Include="Converters\IntToVisibilityConverter.cs" />
     <Compile Include="Converters\IntToBoolConverter.cs" />
+    <Compile Include="Converters\IntToVisibilityConverter.cs" />
+    <Compile Include="Converters\OrientationToVisibilityConverter.cs" />
     <Compile Include="Converters\StretchModeConverter.cs" />
+    <Compile Include="Converters\StringToVisibilityConverter.cs" />
     <Compile Include="DlgRunPolarAlignment.xaml.cs">
       <DependentUpon>DlgRunPolarAlignment.xaml</DependentUpon>
     </Compile>
@@ -115,6 +120,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Controls\Joystick.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\RangeSlider.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/OATControl/PointsOfInterest.xml
+++ b/OATControl/PointsOfInterest.xml
@@ -1,40 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <PointsOfInterest>
-  <Object Name="Polaris (Celestial Pole)"  RA="02:58:51" DEC="89:21:13" />
-  <Object Name="M81 - Bodes Galaxy"        RA="09:57:13" DEC="68:58:01" />
-  <Object Name="Cederblad 214"             RA="00:05:46" DEC="67:16:45" />
-  <Object Name="Heart Nebula - Cassiopeia" RA="02:34:57" DEC="61:31:17" />
-  <Object Name="Soul Nebula - Cassiopeia"  RA="02:52:47" DEC="60:30:56" />
-  <Object Name="Navi - Cassiopeia"         RA="00:57:57" DEC="60:49:33" />
-  <Object Name="Elephant Trunk Nebula"     RA="21:39:44" DEC="57:35:31" />
-  <Object Name="Big Dipper"                RA="12:16:26" DEC="56:55:07" />
-  <Object Name="M101 - Pinwheel Galaxy"    RA="14:03:56" DEC="54:15:00" />
-  <Object Name="M51 - Whirlpool Galaxy"    RA="13:30:45" DEC="47:05:21" />
-  <Object Name="Deneb - Cygnus Nebula"     RA="20:42:07" DEC="45:21:12" />
-  <Object Name="M63 - Sunflower Galaxy"    RA="13:16:45" DEC="41:55:14" />
-  <Object Name="M31 - Andromeda Galaxy"    RA="00:43:52" DEC="41:22:53" />
-  <Object Name="Vega"                      RA="18:37:37" DEC="38:48:07" />
-  <Object Name="Veil Nebula"               RA="20:51:19" DEC="31:03:34" />
-  <Object Name="M33 - Triangulum Nebula"   RA="01:34:59" DEC="30:45:40" />
-  <Object Name="Pleiades - Seven Sisters"  RA="03:48:15" DEC="24:10:54" />
-  <Object Name="Arcturus"                  RA="14:16:37" DEC="19:05:21" />
-  <Object Name="Altair"                    RA="19:51:45" DEC="8:55:15" />
-  <Object Name="M42 - Orion Nebula"        RA="05:36:18" DEC="-5:22:44" />
-  <Object Name="Lagoon Nebula"             RA="18:05:02" DEC="-24:22:52" />
-  <Object Name="Cocoon Nebula"             RA="21:55:13" DEC="47:22:07" />
-  <Object Name="Crescent Nebula"           RA="20:12:54" DEC="38:25:11" />
-  <Object Name="Horsehead Nebula"          RA="05:42:03" DEC="-2:26:52" />
-  <Object Name="Bubble Nebula"             RA="23:21:45" DEC="61:19:10" />
-  <Object Name="California Nebula"         RA="04:04:42" DEC="36:28:50" />
-  <Object Name="Christmas Tree Cluster"    RA="06:52:09" DEC="09:52:07" />
-  <Object Name="Trifid and Lagoon"         RA="18:04:00" DEC="-22:58:16" />
-  <Object Name="Eagle Nebula"              RA="18:20:01" DEC="-13:47:52" />
-  <Object Name="Little Dumbbell Nebula"    RA="01:43:42" DEC="51:41:00" />
-  <Object Name="Croc's Eye Galaxy"         RA="12:52:53" DEC="41:00:12" />
+	<Object Name="Polaris (Celestial Pole)"  RA="02:58:51" DEC="89:21:13" />
+	<Object Name="M81 - Bodes Galaxy"        RA="09:57:13" DEC="68:58:01" />
+	<Object Name="Cederblad 214"             RA="00:05:46" DEC="67:16:45" />
+	<Object Name="Heart Nebula - Cassiopeia" RA="02:34:57" DEC="61:31:17" />
+	<Object Name="Soul Nebula - Cassiopeia"  RA="02:52:47" DEC="60:30:56" />
+	<Object Name="Navi - Cassiopeia"         RA="00:57:57" DEC="60:49:33" />
+	<Object Name="Elephant Trunk Nebula"     RA="21:39:44" DEC="57:35:31" />
+	<Object Name="Big Dipper"                RA="12:16:26" DEC="56:55:07" />
+	<Object Name="M101 - Pinwheel Galaxy"    RA="14:03:56" DEC="54:15:00" />
+	<Object Name="M51 - Whirlpool Galaxy"    RA="13:30:45" DEC="47:05:21" />
+	<Object Name="Deneb - Cygnus Nebula"     RA="20:42:07" DEC="45:21:12" />
+	<Object Name="M63 - Sunflower Galaxy"    RA="13:16:45" DEC="41:55:14" />
+	<Object Name="M31 - Andromeda Galaxy"    RA="00:43:52" DEC="41:22:53" />
+	<Object Name="Vega"                      RA="18:37:37" DEC="38:48:07" />
+	<Object Name="Veil Nebula"               RA="20:51:19" DEC="31:03:34" />
+	<Object Name="M33 - Triangulum Nebula"   RA="01:34:59" DEC="30:45:40" />
+	<Object Name="Pleiades - Seven Sisters"  RA="03:48:15" DEC="24:10:54" />
+	<Object Name="Arcturus"                  RA="14:16:37" DEC="19:05:21" />
+	<Object Name="Altair"                    RA="19:51:45" DEC="8:55:15" />
+	<Object Name="M42 - Orion Nebula"        RA="05:36:18" DEC="-5:22:44" />
+	<Object Name="Orion Belt Cluster"        RA="05:37:18" DEC="-1:09:00" />
+	<Object Name="Lagoon Nebula"             RA="18:05:02" DEC="-24:22:52" />
+	<Object Name="Cocoon Nebula"             RA="21:55:13" DEC="47:22:07" />
+	<Object Name="Crescent Nebula"           RA="20:12:54" DEC="38:25:11" />
+	<Object Name="Horsehead Nebula"          RA="05:42:03" DEC="-2:26:52" />
+	<Object Name="Bubble Nebula"             RA="23:21:45" DEC="61:19:10" />
+	<Object Name="California Nebula"         RA="04:04:42" DEC="36:28:50" />
+	<Object Name="Christmas Tree Cluster"    RA="06:42:09" DEC="09:52:07" />
+	<Object Name="Rosette Nebula"            RA="06:33:03" DEC="04:55:33" />
+	<Object Name="Trifid and Lagoon"         RA="18:04:00" DEC="-22:58:16" />
+	<Object Name="Eagle Nebula"              RA="18:20:01" DEC="-13:47:52" />
+	<!--<Object Name="Little Dumbbell Nebula"    RA="01:43:42" DEC="51:41:00" />-->
+	<Object Name="Croc's Eye Galaxy"         RA="12:52:53" DEC="41:00:12" />
 	<Object Name="Ring Nebula"               RA="18:54:23" DEC="33:03:23" />
 	<Object Name="M104 - Sombrero Galaxy"    RA="12:41:06" DEC="-11:44:28" />
 	<Object Name="Seagull Nebula"            RA="07:05:26" DEC="-10:29:16" />
-  <Object Name="Dolphin Nebula"            RA="01:31:57" DEC="58:31:29" />
-  <Object Name="Cave Nebula"               RA="22:58:08" DEC="62:35:27" />
-  <Object Name="Wizard Nebula"             RA="22:48:12" DEC="58:14:44" />
+	<Object Name="Dolphin Nebula"            RA="01:31:57" DEC="58:31:29" />
+	<Object Name="Cave Nebula"               RA="22:58:08" DEC="62:35:27" />
+	<Object Name="Wizard Nebula"             RA="22:48:12" DEC="58:14:44" />
 </PointsOfInterest>

--- a/OATControl/Properties/AssemblyInfo.cs
+++ b/OATControl/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.9.30")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.2")]
+[assembly: AssemblyFileVersion("1.0.0.2")]

--- a/OATControl/Properties/Settings.Designer.cs
+++ b/OATControl/Properties/Settings.Designer.cs
@@ -118,5 +118,53 @@ namespace OATControl.Properties {
                 this["TargetChooserSize"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowDecLimits {
+            get {
+                return ((bool)(this["ShowDecLimits"]));
+            }
+            set {
+                this["ShowDecLimits"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("-90")]
+        public float LowerDecLimit {
+            get {
+                return ((float)(this["LowerDecLimit"]));
+            }
+            set {
+                this["LowerDecLimit"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("180")]
+        public float UpperDecLimit {
+            get {
+                return ((float)(this["UpperDecLimit"]));
+            }
+            set {
+                this["UpperDecLimit"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("19200")]
+        public string BaudRate {
+            get {
+                return ((string)(this["BaudRate"]));
+            }
+            set {
+                this["BaudRate"] = value;
+            }
+        }
     }
 }

--- a/OATControl/Properties/Settings.settings
+++ b/OATControl/Properties/Settings.settings
@@ -26,5 +26,17 @@
     <Setting Name="TargetChooserSize" Type="System.Drawing.Size" Scope="User">
       <Value Profile="(Default)">670, 910</Value>
     </Setting>
+    <Setting Name="ShowDecLimits" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="LowerDecLimit" Type="System.Single" Scope="User">
+      <Value Profile="(Default)">-90</Value>
+    </Setting>
+    <Setting Name="UpperDecLimit" Type="System.Single" Scope="User">
+      <Value Profile="(Default)">180</Value>
+    </Setting>
+    <Setting Name="BaudRate" Type="System.String" Scope="User">
+      <Value Profile="(Default)">19200</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/OATControl/SettingsDialog.xaml
+++ b/OATControl/SettingsDialog.xaml
@@ -10,6 +10,7 @@
         Title="Settings" MinHeight="610" Width="500" Height="690">
 	<Window.Resources>
 		<converters:IntToVisibilityConverter x:Key="V1_8_76OrLater" Operator=">=" VisibleValue="10876" UseCollapse="True"/>
+		<converters:StringToVisibilityConverter x:Key="CollapseOnStringEqual" EqualState="Collapsed" />
 		<Style x:Key="SmallTextBlockLabel" TargetType="TextBlock" BasedOn="{StaticResource MetroTextBlock}">
 			<Setter Property="VerticalAlignment" Value="Center" />
 			<Setter Property="FontWeight" Value="Bold" />
@@ -206,14 +207,14 @@
 		<TextBlock Grid.Row="15" Grid.Column="0" Text="Temperature:" HorizontalAlignment="Right"  Style="{StaticResource TextBlockLabelSmall}" Margin="0,1.38,2,2.62"/>
 		<TextBlock Grid.Row="15" Grid.Column="1" Text="{Binding ScopeTemperature}"  Style="{StaticResource TextBlockLabelValue}" Margin="0,3.38,0,4.62"/>
 
-		<TextBlock Grid.Row="16" Grid.Column="0" Text="Network:" HorizontalAlignment="Right"  Style="{StaticResource TextBlockLabelSmall}" Margin="0,1.38,1,1.62"/>
-		<TextBlock Grid.Row="16" Grid.Column="1" Text="{Binding ScopeNetworkState}"  Style="{StaticResource TextBlockLabelValue}" Margin="0,3.38,0,3.62"/>
+		<TextBlock Grid.Row="16" Grid.Column="0" Text="Network:" HorizontalAlignment="Right"  Style="{StaticResource TextBlockLabelSmall}" Margin="0,1.38,1,1.62" Visibility="{Binding ScopeNetworkState, Converter={StaticResource CollapseOnStringEqual}, ConverterParameter={}Disabled}"/>
+		<TextBlock Grid.Row="16" Grid.Column="1" Text="{Binding ScopeNetworkState}"  Style="{StaticResource TextBlockLabelValue}" Margin="0,3.38,0,3.62" Visibility="{Binding ScopeNetworkState, Converter={StaticResource CollapseOnStringEqual}, ConverterParameter={}Disabled}"/>
 
-		<TextBlock Grid.Row="17" Grid.Column="0" Text="IP:" HorizontalAlignment="Right"  Style="{StaticResource TextBlockLabelSmall}" Margin="0,1.38,2,1.62"/>
-		<TextBlock Grid.Row="17" Grid.Column="1" Text="{Binding ScopeNetworkIPAddress}"  Style="{StaticResource TextBlockLabelValue}" Margin="0,3.38,0,3.62"/>
+		<TextBlock Grid.Row="17" Grid.Column="0" Text="IP:" HorizontalAlignment="Right"  Style="{StaticResource TextBlockLabelSmall}" Margin="0,1.38,2,1.62" Visibility="{Binding ScopeNetworkState, Converter={StaticResource CollapseOnStringEqual}, ConverterParameter={}Disabled}"/>
+		<TextBlock Grid.Row="17" Grid.Column="1" Text="{Binding ScopeNetworkIPAddress}"  Style="{StaticResource TextBlockLabelValue}" Margin="0,3.38,0,3.62" Visibility="{Binding ScopeNetworkState, Converter={StaticResource CollapseOnStringEqual}, ConverterParameter={}Disabled}"/>
 
-		<TextBlock Grid.Row="18" Grid.Column="0" Text="SSID:" HorizontalAlignment="Right"  Style="{StaticResource TextBlockLabelSmall}" Margin="0,2.38,1,1.62"/>
-		<TextBlock Grid.Row="18" Grid.Column="1" Text="{Binding ScopeNetworkSSID}"  Style="{StaticResource TextBlockLabelValue}" Margin="0,4.38,0,3.62"/>
+		<TextBlock Grid.Row="18" Grid.Column="0" Text="SSID:" HorizontalAlignment="Right"  Style="{StaticResource TextBlockLabelSmall}" Margin="0,2.38,1,1.62" Visibility="{Binding ScopeNetworkState, Converter={StaticResource CollapseOnStringEqual}, ConverterParameter={}Disabled}"/>
+		<TextBlock Grid.Row="18" Grid.Column="1" Text="{Binding ScopeNetworkSSID}"  Style="{StaticResource TextBlockLabelValue}" Margin="0,4.38,0,3.62" Visibility="{Binding ScopeNetworkState, Converter={StaticResource CollapseOnStringEqual}, ConverterParameter={}Disabled}"/>
 
 		<StackPanel Grid.Row="20" Grid.ColumnSpan="5" HorizontalAlignment="Right" Orientation="Horizontal" Margin="0,9.38,0,-0.38" Grid.RowSpan="2">
 			<Button Margin="16,8,8,8" Padding="20,0" Content="Factory Reset" HorizontalAlignment="Right" Style="{StaticResource AccentedSquareButtonStyle}" Command="{Binding FactoryResetCommand}"/>

--- a/OATControl/TargetChooser.xaml
+++ b/OATControl/TargetChooser.xaml
@@ -1,23 +1,24 @@
-﻿<Window x:Class="OATControl.TargetChooser"
+﻿<mah:MetroWindow x:Class="OATControl.TargetChooser"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+		xmlns:mah="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
         xmlns:local="clr-namespace:OATControl"
         xmlns:converters="clr-namespace:OATControl.Converters"
         mc:Ignorable="d"
-        Title="Target Chooser" Height="950" Width="800">
+        Title="Target Chooser" Height="774" MinHeight="280" Width="466" MinWidth="210" MaxWidth="466">
 	<Window.Resources>
 		<converters:DoubleToHMSConverter x:Key="RAConverter" />
 		<converters:DoubleToHMSConverter x:Key="DECConverter" Formatter = "[0:+00;-00]° [1:00]&quot; [2:00]'"/>
 		<converters:DoubleToHMSConverter x:Key="DECNoSignConverter" Formatter = "[0:00]° [1:00]&quot; [2:00]'"/>
 
-		<converters:DoubleToGridLengthDividerConverter x:Key="RADiffConverter" Divisor= "6"/>
-		<converters:DoubleToGridLengthDividerConverter x:Key="RADiffInvertConverter" Divisor= "6" Inverter="6"/>
-		<converters:DoubleToGridLengthDividerConverter x:Key="DECDiffConverter" Divisor= "180"/>
-		<converters:DoubleToGridLengthDividerConverter x:Key="DECDiffInvertConverter" Divisor= "180" Inverter="180"/>
-		<converters:DoubleToGridLengthDividerConverter x:Key="DistDiffConverter" Divisor= "8.4853"/>
-		<converters:DoubleToGridLengthDividerConverter x:Key="DistDiffInvertConverter" Divisor= "8.4853" Inverter="8.4853"/>
+		<converters:DoubleToGridLengthDividerConverter x:Key="RADiffConverter" Divisor= "1"/>
+		<converters:DoubleToGridLengthDividerConverter x:Key="RADiffInvertConverter" Divisor= "1" Inverter="100"/>
+		<converters:DoubleToGridLengthDividerConverter x:Key="DECDiffConverter" Divisor= "1"/>
+		<converters:DoubleToGridLengthDividerConverter x:Key="DECDiffInvertConverter" Divisor= "1" Inverter="100"/>
+		<converters:DoubleToGridLengthDividerConverter x:Key="DistDiffConverter" Divisor= "1"/>
+		<converters:DoubleToGridLengthDividerConverter x:Key="DistDiffInvertConverter" Divisor= "1" Inverter="100"/>
 
 		<Style x:Key="HeaderStyle" TargetType="TextBlock" >
 			<Setter Property="FontSize" Value="16" />
@@ -111,8 +112,8 @@
 			<Grid>
 				<Grid>
 					<Grid.ColumnDefinitions>
-						<ColumnDefinition Width="{Binding RADistance, Converter={StaticResource RADiffConverter}}" />
-						<ColumnDefinition Width="{Binding RADistance, Converter={StaticResource RADiffInvertConverter}}" />
+						<ColumnDefinition Width="{Binding RAStepDistance, Converter={StaticResource RADiffConverter}}" />
+						<ColumnDefinition Width="{Binding RAStepDistance, Converter={StaticResource RADiffInvertConverter}}" />
 					</Grid.ColumnDefinitions>
 
 					<Border Grid.Column="0"  >
@@ -142,8 +143,8 @@
 			<Grid>
 				<Grid>
 					<Grid.ColumnDefinitions>
-						<ColumnDefinition Width="{Binding DECDistance, Converter={StaticResource DECDiffConverter}}" />
-						<ColumnDefinition Width="{Binding DECDistance, Converter={StaticResource DECDiffInvertConverter}}" />
+						<ColumnDefinition Width="{Binding DECStepDistance, Converter={StaticResource DECDiffConverter}}" />
+						<ColumnDefinition Width="{Binding DECStepDistance, Converter={StaticResource DECDiffInvertConverter}}" />
 					</Grid.ColumnDefinitions>
 
 					<Border Grid.Column="0"  >
@@ -161,12 +162,32 @@
 			</Grid>
 		</DataTemplate>
 
+		<DataTemplate x:Key="DecPosCellTemplate">
+			<Grid>
+				<TextBlock Foreground="#000" Padding="10,0" HorizontalAlignment="Stretch" >
+					<TextBlock.Text>
+						<Binding Path="DECPosition" />
+					</TextBlock.Text>
+				</TextBlock>
+			</Grid>
+		</DataTemplate>
+
+		<DataTemplate x:Key="RaPosCellTemplate">
+			<Grid>
+				<TextBlock Foreground="#000" Padding="10,0" HorizontalAlignment="Stretch" >
+					<TextBlock.Text>
+						<Binding Path="RAPosition" />
+					</TextBlock.Text>
+				</TextBlock>
+			</Grid>
+		</DataTemplate>
+
 		<DataTemplate x:Key="DistCellTemplate">
 			<Grid>
 				<Grid>
 					<Grid.ColumnDefinitions>
-						<ColumnDefinition Width="{Binding Distance, Converter={StaticResource DistDiffConverter}}" />
-						<ColumnDefinition Width="{Binding Distance, Converter={StaticResource DistDiffInvertConverter}}" />
+						<ColumnDefinition Width="{Binding DistanceNormalized, Converter={StaticResource DistDiffConverter}}" />
+						<ColumnDefinition Width="{Binding DistanceNormalized, Converter={StaticResource DistDiffInvertConverter}}" />
 					</Grid.ColumnDefinitions>
 
 					<Border Grid.Column="0"  >
@@ -178,12 +199,12 @@
 				</Grid>
 				<TextBlock Foreground="#000" Padding="10,0" HorizontalAlignment="Center" FontWeight="Bold">
 					<TextBlock.Text>
-						<Binding Path="Distance" StringFormat="{}{0:0.000}"/>
+						<Binding Path="DistanceNormalized" StringFormat="{}{0:0}"/>
 					</TextBlock.Text>
 				</TextBlock>
 			</Grid>
 		</DataTemplate>
-		
+
 		<!--<Style x:Key="ListHeaderStyle" TargetType="{x:Type GridViewColumnHeader}">
 			<Setter Property="BorderBrush" Value="#CC0"/>
 			<Setter Property="Background" Value="#9C0"/>
@@ -224,15 +245,27 @@
 					<Setter Property="BorderBrush" Value="#A00" />
 					<Setter Property="BorderThickness" Value="1" />
 				</Trigger>
+				<DataTrigger Binding="{Binding IsReachable}" Value="false">
+					<Setter Property="Background" Value="#400" />
+					<Setter Property="BorderBrush" Value="#500000" />
+					<Setter Property="Foreground" Value="#A00"/>
+				</DataTrigger>
+				<MultiDataTrigger >
+					<MultiDataTrigger.Conditions>
+						<Condition Binding="{Binding ElementName=ShowReachable, Path=IsChecked}" Value="True" />
+						<Condition Binding="{Binding IsReachable}" Value="False" />
+					</MultiDataTrigger.Conditions>
+					<Setter Property="Visibility" Value="Collapsed" />
+				</MultiDataTrigger>
 			</Style.Triggers>
 		</Style>
-		
+
 		<Style x:Key="GridViewColumnHeaderStyle1" TargetType="{x:Type GridViewColumnHeader}">
 			<Setter Property="Template">
 				<Setter.Value>
 					<ControlTemplate TargetType="{x:Type GridViewColumnHeader}">
 						<Border BorderThickness="0,0,0,1" BorderBrush="#C00" Background="Transparent">
-							<TextBlock x:Name="ContentHeader" Text="{TemplateBinding Content}" Padding="5,5,5,0" Width="{TemplateBinding Width}" TextAlignment="Center" MouseLeftButtonUp="TextBlock_MouseUp" />
+							<TextBlock x:Name="ContentHeader" Text="{TemplateBinding Content}" Padding="5,5,5,0" Width="{TemplateBinding Width}" TextAlignment="Center" />
 						</Border>
 					</ControlTemplate>
 				</Setter.Value>
@@ -248,15 +281,37 @@
 
 	</Window.Resources>
 
-	<Grid ScrollViewer.VerticalScrollBarVisibility="Auto">
-		<ListView ItemsSource="{Binding AvailablePointsOfInterest}" HorizontalAlignment="Center" >
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<mah:ToggleSwitch 
+			x:Name="ShowReachable" 
+			Grid.Row="0" 
+			Header="" 
+			OnLabel="Hiding Unreachable Targets" 
+			OffLabel="Showing Unreachable Targets" 
+			Margin="0,0" 
+			Padding="0" 
+			Foreground="#F00"
+			mah:ControlsHelper.HeaderFontSize="15" 
+			HorizontalAlignment="Center" 
+			ContentPadding="51,0,0,0" 
+			mah:ControlsHelper.HeaderMargin="0,0,0,3"
+			ThumbIndicatorBrush="#D00"
+			/>
+		<ListView Grid.Row="1" ItemsSource="{Binding AvailablePointsOfInterest}" HorizontalAlignment="Center" >
 			<ListView.View>
 				<GridView  ColumnHeaderContainerStyle="{StaticResource GridViewColumnHeaderStyle1}" >
 					<GridViewColumn Header="Name" CellTemplate="{StaticResource NameCellTemplate}" HeaderTemplate="{StaticResource myHeaderTemplate}"/>
 					<GridViewColumn Header="RA" CellTemplate="{StaticResource RaCellTemplate}"/>
-					<GridViewColumn Header="RA Dist" CellTemplate="{StaticResource RaDistCellTemplate}"/>
+					<!--<GridViewColumn Header="RA Pos" CellTemplate="{StaticResource RaPosCellTemplate}"/>-->
+					<!--<GridViewColumn Header="RA Dist" CellTemplate="{StaticResource RaDistCellTemplate}"/>-->
 					<GridViewColumn Header="DEC"  CellTemplate="{StaticResource DecCellTemplate}"/>
-					<GridViewColumn Header="DEC Dist"  CellTemplate="{StaticResource DecDistCellTemplate}"/>
+					<!--<GridViewColumn Header="DEC Pos"  CellTemplate="{StaticResource DecPosCellTemplate}"/>-->
+					<!--<GridViewColumn Header="DEC Dist"  CellTemplate="{StaticResource DecDistCellTemplate}"/>-->
 					<GridViewColumn Header="Distance" Width="90" CellTemplate="{StaticResource DistCellTemplate}" />
 				</GridView>
 			</ListView.View>
@@ -363,4 +418,4 @@
 		</ListView>
 	</Grid>
 		-->
-</Window>
+</mah:MetroWindow>

--- a/OATControl/TargetChooser.xaml.cs
+++ b/OATControl/TargetChooser.xaml.cs
@@ -1,6 +1,9 @@
-﻿using OATControl.ViewModels;
+﻿using MahApps.Metro.Controls;
+using OATControl.Properties;
+using OATControl.ViewModels;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -18,7 +21,7 @@ namespace OATControl
 	/// <summary>
 	/// Interaction logic for TargetChooser.xaml
 	/// </summary>
-	public partial class TargetChooser : Window
+	public partial class TargetChooser : MetroWindow
 	{
 		public TargetChooser(MountVM mount)
 		{
@@ -26,6 +29,19 @@ namespace OATControl
 			InitializeComponent();
 		}
 
+		protected override void OnClosing(CancelEventArgs e)
+		{
+			Settings.Default.TargetChooserPos = new System.Drawing.Point((int)this.Left, (int)this.Top);
+			Settings.Default.TargetChooserSize = new System.Drawing.Size((int)this.Width, (int)this.Height);
+			base.OnClosing(e);
+		}
+		
+		protected override void OnClosed(EventArgs e)
+		{
+			base.OnClosed(e);
+			(this.DataContext as MountVM).TargetChooserClosed();
+		}
+		
 		protected void HandleDoubleClick(object sender, MouseButtonEventArgs args)
 		{
 			var point = (args.Source as ListViewItem).Content as PointOfInterest;
@@ -33,12 +49,6 @@ namespace OATControl
 			{
 				(this.DataContext as MountVM).SelectedPointOfInterest = point;
 			}
-		}
-
-		private void TextBlock_MouseUp(object sender, MouseButtonEventArgs e)
-		{
-			TextBlock source = sender as TextBlock;
-			//source.Text
 		}
 	}
 }

--- a/OATControl/ViewModels/PointsOfInterest.cs
+++ b/OATControl/ViewModels/PointsOfInterest.cs
@@ -9,9 +9,11 @@ namespace OATControl.ViewModels
 {
 	public class PointsOfInterest : List<PointOfInterest>
 	{
+		private long _decLowLimit = -99999999;
+		private long _decHighLimit = 99999999;
+
 		public PointsOfInterest()
 		{
-
 		}
 
 		public PointsOfInterest(IEnumerable<PointOfInterest> i)
@@ -38,11 +40,19 @@ namespace OATControl.ViewModels
 			}
 		}
 
-		public void CalcDistancesFrom(double ra, double dec)
+		public void CalcDistancesFrom(double ra, double dec, long raPos, long decPos)
 		{
 			foreach (var point in this)
 			{
-				point.CalcDistancesFrom(ra, dec);
+				point.CalcDistancesFrom(ra, dec, raPos, decPos);
+			}
+
+			double maxDecPos = this.Max(p => Math.Abs(p.DECPosition - decPos));
+			double maxRaPos = this.Max(p => Math.Abs(p.RAPosition - raPos));
+			double maxDist = this.Max(p => p.Distance);
+			foreach (var point in this)
+			{
+				point.Normalize(maxRaPos, maxDecPos, maxDist);
 			}
 		}
 
@@ -55,6 +65,26 @@ namespace OATControl.ViewModels
 			if (field == "Distance")
 			{
 				this.Sort((p1, p2) => { return p1.Distance.CompareTo(p2.Distance); });
+			}
+		}
+
+		internal void SetDecLowStepLimit(long decStepper)
+		{
+			_decLowLimit = decStepper;
+			CheckPointReachability();
+		}
+
+		internal void SetDecHighStepLimit(long decStepper)
+		{
+			_decHighLimit = decStepper;
+			CheckPointReachability();
+		}
+
+		void CheckPointReachability()
+		{
+			foreach (var point in this)
+			{
+				point.IsReachable = (point.DECPosition >= _decLowLimit) && (point.DECPosition <= _decHighLimit);
 			}
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ To install any of these, click on the latest release under Releases to the right
 
 Change Log:
 ===========
+**V1.0.0.2 - Updates**
+- Improved Target Chooser display. Fewer columns, better readability, DEC limits filtering.
+- Added axis displays for RA and DEC that show current and target position, as well as limits on DEC (if set). Also added a button to set the lower limit from the current position.
+- Added Baudrate selection step in connection dialog (Firmware V1.9.04 and later use 19200, earlier versions use 57600)
+- Increased the time needed to start changing Target coodinates with mouse before they auto-incremented or decremented.
+- Slew progress now uses actual stepper positions instead of stellar coordinates.
+- Users now get asked to confirm if the want to slew to a location that is outside of the set DEC limits.
+- Updated Polaris coordinates for Polar Alignment function 
+- Hid the network settings the Settings dialog if no Wifi is enabled.
+- Fixed a crash caused by trying to send a command to a disconnected device.
+- Fixed a crash caused by reading temperature without the addon hardware present.
+- Fixed a sporadic crash in connection dialog.
+- Fixed a sporadic inability to shutdown properly after more than one connection session.
+
 **V0.9.9.30 - Updates**
 - Revamped target choice into it's own modeless dialog. Targets are sorted by distance from current target. Double-click to transfer coordinates to target.
 - Improved connectivity failure detection. Attempt a few retries.


### PR DESCRIPTION
- Improved Target Chooser display. Fewer columns, better readability, DEC limits filtering.
- Added axis displays for RA and DEC that show current and target position, as well as limits on DEC (if set). Also added a button to set the lower limit from the current position.
- Added Baudrate selection step in connection dialog (Firmware V1.9.04 and later use 19200, earlier versions use 57600)
- Increased the time needed to start changing Target coodinates with mouse before they auto-incremented or decremented.
- Slew progress now uses actual stepper positions instead of stellar coordinates.
- Users now get asked to confirm if the want to slew to a location that is outside of the set DEC limits.
- Updated Polaris coordinates for Polar Alignment function 
- Hid the network settings the Settings dialog if no Wifi is enabled.
- Fixed a crash caused by trying to send a command to a disconnected device.
- Fixed a crash caused by reading temperature without the addon hardware present.
- Fixed a sporadic crash in connection dialog.
- Fixed a sporadic inability to shutdown properly after more than one connection session.
