### PR TITLE
Fix deadlocks, TCP stability, and ASCOM registration issues

### DIFF
--- a/ASCOM.Driver/OpenAstroTracker/LocalServer.cs
+++ b/ASCOM.Driver/OpenAstroTracker/LocalServer.cs
@@ -397,7 +397,7 @@ namespace ASCOM.OpenAstroTracker
                         key.CreateSubKey("Programmable");
                         using (RegistryKey key2 = key.CreateSubKey("LocalServer32"))
                         {
-                            key2.SetValue(null, Application.ExecutablePath);
+                            key2.SetValue(null, "\"" + Application.ExecutablePath + "\"");
                         }
                     }
                     //

--- a/ASCOM.Driver/OpenAstroTracker/OpenAstroTracker.csproj
+++ b/ASCOM.Driver/OpenAstroTracker/OpenAstroTracker.csproj
@@ -42,7 +42,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -62,37 +62,37 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ASCOM.Astrometry, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
-      <HintPath>packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Astrometry.dll</HintPath>
+      <HintPath>..\packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Astrometry.dll</HintPath>
     </Reference>
     <Reference Include="ASCOM.Attributes, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
-      <HintPath>packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Attributes.dll</HintPath>
+      <HintPath>..\packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="ASCOM.Cache, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
-      <HintPath>packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Cache.dll</HintPath>
+      <HintPath>..\packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Cache.dll</HintPath>
     </Reference>
     <Reference Include="ASCOM.Controls, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
-      <HintPath>packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Controls.dll</HintPath>
+      <HintPath>..\packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Controls.dll</HintPath>
     </Reference>
     <Reference Include="ASCOM.DeviceInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
-      <HintPath>packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.DeviceInterfaces.dll</HintPath>
+      <HintPath>..\packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.DeviceInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="ASCOM.DriverAccess, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
-      <HintPath>packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.DriverAccess.dll</HintPath>
+      <HintPath>..\packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.DriverAccess.dll</HintPath>
     </Reference>
     <Reference Include="ASCOM.Exceptions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
-      <HintPath>packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Exceptions.dll</HintPath>
+      <HintPath>..\packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Exceptions.dll</HintPath>
     </Reference>
     <Reference Include="ASCOM.Internal.Extensions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
-      <HintPath>packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Internal.Extensions.dll</HintPath>
+      <HintPath>..\packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Internal.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="ASCOM.SettingsProvider, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
-      <HintPath>packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.SettingsProvider.dll</HintPath>
+      <HintPath>..\packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.SettingsProvider.dll</HintPath>
     </Reference>
     <Reference Include="ASCOM.Utilities, Version=6.0.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
-      <HintPath>packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Utilities.dll</HintPath>
+      <HintPath>..\packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Utilities.dll</HintPath>
     </Reference>
     <Reference Include="ASCOM.Utilities.Video, Version=6.1.0.0, Culture=neutral, PublicKeyToken=565de7938946fba7, processorArchitecture=MSIL">
-      <HintPath>packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Utilities.Video.dll</HintPath>
+      <HintPath>..\packages\ASCOM.Platform.6.4.2\lib\net40\ASCOM.Utilities.Video.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/ASCOM.Driver/OpenAstroTracker/SharedResources.cs
+++ b/ASCOM.Driver/OpenAstroTracker/SharedResources.cs
@@ -250,6 +250,10 @@ namespace ASCOM.OpenAstroTracker
 				else
 				{
 					LogMessage(LoggingFlags.Serial, $"SendMessage Nr{messageNr,0:0000} - Not connected or Empty Message: " + message);
+					if (!SharedSerial.Connected)
+					{
+						throw new ASCOM.NotConnectedException($"SendMessage called while serial port is disconnected. Command: {message}");
+					}
 				}
 				LogMessage(LoggingFlags.Serial, $"SendMessage Nr{messageNr,0:0000} - Releasing lock");
 			}

--- a/ASCOM.Driver/TelescopeDriver/Driver.cs
+++ b/ASCOM.Driver/TelescopeDriver/Driver.cs
@@ -83,8 +83,23 @@ namespace ASCOM.OpenAstroTracker
 		///     ''' the new settings are saved, otherwise the old values are reloaded.
 		///     ''' THIS IS THE ONLY PLACE WHERE SHOWING USER INTERFACE IS ALLOWED!
 		///     ''' </summary>
+		[System.Runtime.InteropServices.DllImport("user32.dll")]
+		private static extern bool SetForegroundWindow(IntPtr hWnd);
+
 		public void SetupDialog()
 		{
+			// When started by COM (-embedding), Windows denies this process foreground
+			// privilege, so SetupDialogForm.ShowDialog() opens but never gets focus.
+			// Call SetForegroundWindow on the main form's handle to regain foreground
+			// status before showing the modal setup dialog. SetupDialog() runs on the
+			// main STA thread, so we can call these APIs directly.
+			var mainForm = System.Windows.Forms.Application.OpenForms.Count > 0
+				? System.Windows.Forms.Application.OpenForms[0] : null;
+			if (mainForm != null)
+			{
+				mainForm.WindowState = System.Windows.Forms.FormWindowState.Normal;
+				SetForegroundWindow(mainForm.Handle);
+			}
 			using (var f = new SetupDialogForm(Profile, this, (s) => this.LogMessage(LoggingFlags.Setup, s)))
 			{
 				if (f.ShowDialog() == DialogResult.OK)
@@ -93,6 +108,9 @@ namespace ASCOM.OpenAstroTracker
 					SharedResources.SetTraceFlags(Profile.TraceFlags);
 				}
 			}
+			// Re-minimize frmMain after setup dialog is dismissed
+			if (mainForm != null && Server.StartedByCOM)
+				mainForm.WindowState = System.Windows.Forms.FormWindowState.Minimized;
 		}
 
 		public ArrayList SupportedActions
@@ -1353,17 +1371,26 @@ namespace ASCOM.OpenAstroTracker
 				throw new NotConnectedException(message);
 		}
 
-		private int PollUntilZero(string command)
+		private int PollUntilZero(string command, int maxAttempts = 120)
 		{
 			// Takes a command to be sent via CommandString, and resends every 1000ms until a 0 is returned.  Returns 0 only when complete.
+			// maxAttempts caps the wait to prevent hanging indefinitely if the mount stalls or communication fails (default: 120s).
 			string retVal = "";
-			while (retVal != "0")
+			int attempts = 0;
+			while (retVal != "0" && attempts < maxAttempts)
 			{
 				retVal = CommandString(command);
-				LogMessage(LoggingFlags.Scope, $"PollUntilZero - Command: {command}, Response: {retVal}");
+				LogMessage(LoggingFlags.Scope, $"PollUntilZero - Command: {command}, Response: {retVal}, Attempt: {attempts + 1}/{maxAttempts}");
 				if (retVal == "0")
 					break;
+				attempts++;
 				Thread.Sleep(1000);
+			}
+
+			if (attempts >= maxAttempts)
+			{
+				LogMessage(LoggingFlags.Scope, $"PollUntilZero - Timed out after {maxAttempts} attempts for command: {command}");
+				throw new System.TimeoutException($"Mount did not complete operation within {maxAttempts} seconds. Command: {command}");
 			}
 
 			return System.Convert.ToInt32(retVal);

--- a/OATCommunications/CommunicationHandlers/TcpCommunicationHandler.cs
+++ b/OATCommunications/CommunicationHandlers/TcpCommunicationHandler.cs
@@ -1,4 +1,4 @@
-﻿using OATCommunications.ClientAdapters;
+using OATCommunications.ClientAdapters;
 using OATCommunications.Utilities;
 using System;
 using System.Collections.Generic;
@@ -16,6 +16,7 @@ namespace OATCommunications.CommunicationHandlers
 		private IPAddress _ip;
 		private int _port;
 		private TcpClient _client;
+		private NetworkStream _stream;
 		private List<string> _available;
 		private Action<string> _addCallback;
 
@@ -67,12 +68,17 @@ namespace OATCommunications.CommunicationHandlers
 			while ((attempt < 4) && (_client != null))
 			{
 				Log.WriteLine("TCP: [{0}] Attempt {1} to send command.", command, attempt);
-				if (!_client.Connected)
+
+				// Only (re)connect when the stream has been closed due to an error, or on first use.
+				if (_stream == null)
 				{
 					try
 					{
 						_client = new TcpClient();
 						_client.Connect(_ip, _port);
+						_client.ReceiveTimeout = 1000;
+						_client.SendTimeout = 1000;
+						_stream = _client.GetStream();
 					}
 					catch (Exception e)
 					{
@@ -82,21 +88,19 @@ namespace OATCommunications.CommunicationHandlers
 					}
 				}
 
-				_client.ReceiveTimeout = 1000;
-				_client.SendTimeout = 1000;
-
 				string error = String.Empty;
 
-				var stream = _client.GetStream();
 				var bytes = Encoding.ASCII.GetBytes(command);
 				try
 				{
-					stream.Write(bytes, 0, bytes.Length);
+					_stream.Write(bytes, 0, bytes.Length);
 					Log.WriteLine("TCP: [{0}] Sent command!", command);
 				}
 				catch (Exception e)
 				{
 					Log.WriteLine("TCP: [{0}] Unable to write command to stream: {1}", command, e.Message);
+					_stream.Close();
+					_stream = null;
 					job.OnFulFilled(new CommandResponse("", false, $"Failed to send message: {e.Message}"));
 					return;
 				}
@@ -110,13 +114,12 @@ namespace OATCommunications.CommunicationHandlers
 							Log.WriteLine("TCP: [{0}] No reply needed to command", command);
 							break;
 
-						case ResponseType.DoubleFullResponse:
 						case ResponseType.DigitResponse:
 						case ResponseType.FullResponse:
 							{
 								Log.WriteLine("TCP: [{0}] Expecting a {1} reply to command, waiting...", command, job.ResponseType.ToString());
 								var response = new byte[256];
-								var respCount = stream.Read(response, 0, response.Length);
+								var respCount = _stream.Read(response, 0, response.Length);
 								respString = Encoding.ASCII.GetString(response, 0, respCount);
 								Log.WriteLine("TCP: [{0}] Received reply to command -> [{1}], trimming", command, respString);
 								int hashPos = respString.IndexOf('#');
@@ -128,22 +131,43 @@ namespace OATCommunications.CommunicationHandlers
 								attempt = 10;
 							}
 							break;
+
+						case ResponseType.DoubleFullResponse:
+							{
+								Log.WriteLine("TCP: [{0}] Expecting a DoubleFullResponse reply to command, waiting...", command);
+								var response = new byte[256];
+								var respCount = _stream.Read(response, 0, response.Length);
+								respString = Encoding.ASCII.GetString(response, 0, respCount);
+								Log.WriteLine("TCP: [{0}] Received first reply to command -> [{1}], trimming", command, respString);
+								int hashPos = respString.IndexOf('#');
+								if (hashPos > 0)
+								{
+									respString = respString.Substring(0, hashPos);
+								}
+								Log.WriteLine("TCP: [{0}] Returning first reply to command -> [{1}]", command, respString);
+								// Read and discard the second response
+								var response2 = new byte[256];
+								_stream.Read(response2, 0, response2.Length);
+								attempt = 10;
+							}
+							break;
 					}
 				}
 				catch (Exception e)
 				{
 					Log.WriteLine("TCP: [{0}] Failed to read reply to command. {1} thrown", command, e.GetType().Name);
-					if (job.ResponseType != ResponseType.NoResponse)
-					{
-						respString = "0#";
-					}
+					_stream.Close();
+					_stream = null;
+					respString = string.Empty;
 				}
 
-				stream.Close();
 				attempt++;
+				// Stream is intentionally left open for the next command.
 			}
 
-			job.OnFulFilled(new CommandResponse(respString));
+			bool succeeded = job.ResponseType == ResponseType.NoResponse || !string.IsNullOrEmpty(respString);
+			job.OnFulFilled(new CommandResponse(respString, succeeded, succeeded ? string.Empty : $"Failed to read reply to [{command}]"));
+
 		}
 
 		public override bool Connected
@@ -185,6 +209,11 @@ namespace OATCommunications.CommunicationHandlers
 				waitQuit.WaitOne();
 
 				Log.WriteLine("TCP: Closing port.");
+				if (_stream != null)
+				{
+					_stream.Close();
+					_stream = null;
+				}
 				_client.Close();
 				_client = null;
 				Log.WriteLine("TCP: Disconnected...");

--- a/OATCommunications/TelescopeCommandHandlers/OatmealTelescopeCommandHandlers.cs
+++ b/OATCommunications/TelescopeCommandHandlers/OatmealTelescopeCommandHandlers.cs
@@ -43,6 +43,7 @@ namespace OATCommunications
 					MountState.Declination = GetCompactDec(parts[6]);
 					success = true;
 				}
+				doneEvent.Set();
 			});
 
 			await doneEvent.WaitAsync();
@@ -273,6 +274,7 @@ namespace OATCommunications
 			SendCommand($":MS#,n", (moveResult) =>
 			{
 				success = success && moveResult.Success && moveResult.Data == "1";
+				doneEvent.Set();
 			});
 
 			await doneEvent.WaitAsync();
@@ -361,8 +363,6 @@ namespace OATCommunications
 			bool success = false;
 			AsyncAutoResetEvent doneEvent = new AsyncAutoResetEvent();
 
-
-			await doneEvent.WaitAsync();
 			// Longitude
 			success = await SetSiteLongitude((float)lon) == "1";
 


### PR DESCRIPTION
Please see attached markdown files for all detailed changes and fixes in this PR. 
[BUILD_FIXES.md](https://github.com/user-attachments/files/25873899/BUILD_FIXES.md)
[CHANGES.md](https://github.com/user-attachments/files/25873900/CHANGES.md)

## Summary

This PR fixes 11 bugs identified while using the ASCOM driver with N.I.N.A. and OATControl
on a BTT SKR Pico v1.0 running firmware V1.13.9. The issues range from permanent UI/thread
deadlocks to silent communication failures and COM registration problems.

Full details for each fix (problem, change, and rationale) are documented in `CHANGES.md`
and `BUILD_FIXES.md`, which I'll attach as comments below.

---

## Runtime Bug Fixes (`OATCommunications`, `ASCOM.Driver`)

**Fix 1 — `Slew()` deadlock** (`OatmealTelescopeCommandHandlers.cs`)
`doneEvent.Set()` was missing from the `:MS#` callback — `await doneEvent.WaitAsync()` hung
forever. Added `doneEvent.Set()` inside the `:MS#` callback.

**Fix 2 — `SetLocation()` deadlock** (`OatmealTelescopeCommandHandlers.cs`)
A premature `await doneEvent.WaitAsync()` appeared before any commands were sent, making all
location/time commands unreachable. Removed the spurious wait.

**Fix 3 — `RefreshMountState()` deadlock** (`OatmealTelescopeCommandHandlers.cs`)
`doneEvent.Set()` was inside `if (status.Success)` — a comm failure meant it was never called
and the method hung. Moved `Set()` outside the `if` block.

**Fix 4 — TCP timeout reported as success** (`TcpCommunicationHandler.cs`)
A catch block substituted `"0#"` as a fake response, which `CommandResponse` treated as
success. Replaced with `string.Empty` and an explicit `succeeded` flag.

**Fix 5 — `DoubleFullResponse` only reads once over TCP** (`TcpCommunicationHandler.cs`)
`DoubleFullResponse` was grouped with single-response types — only one read happened, leaving
the second `#`-terminated reply in the buffer and corrupting the next command's response.
Split into its own `case` block with two reads, matching `SerialCommunicationHandler`.

**Fix 6 — TCP stream leak on write failure** (`TcpCommunicationHandler.cs`)
An early `return` on write failure bypassed `stream.Close()`, leaking the socket handle.
Added `stream.Close()` before the early return.

**Fix 7 — TCP reconnects on every command** (`TcpCommunicationHandler.cs`)
`stream.Close()` after every command closed the underlying socket, so `_client.Connected` was
always `false` and every command triggered a full TCP handshake. Added a `_stream` field to
keep the connection open; reconnects only when `_stream == null`.

**Fix 8 — `SendMessage()` silently returns empty when disconnected** (`SharedResources.cs`)
When `SharedSerial.Connected` was `false`, `SendMessage()` returned `string.Empty` —
indistinguishable from a legitimate empty response. Now throws `ASCOM.NotConnectedException`.

**Fix 9 — `PollUntilZero()` hangs forever on mount stall** (`Driver.cs`)
No timeout — a stalled mount or repeated `"255"` error returns from `CommandString()` caused
`FindHome()`, `Park()`, and synchronous slews to block the driver thread permanently. Added
`maxAttempts = 120` (2-minute cap); throws `TimeoutException` on expiry.

**Fix 10 — `LocalServer32` registry path not quoted** (`LocalServer.cs`)
`Application.ExecutablePath` was written without quotes. Paths with spaces caused
`CO_E_SERVER_EXEC_FAILURE` at COM activation. Wrapped in double quotes.

**Fix 11 — `SetupDialog()` invisible when called from N.I.N.A.** (`Driver.cs`)
COM-started processes are denied foreground privilege by Windows. `SetupDialogForm` opened but
was silently hidden behind other windows. Added `SetForegroundWindow()` on the main form
handle before `ShowDialog()` to regain foreground status.

---

## Build / Project Fixes (`OpenAstroTracker.csproj`)

**Build Fix 4 — Wrong NuGet HintPaths for ASCOM assemblies**
HintPaths pointed to `packages\` (inside the project dir) instead of `..\packages\` (the
actual NuGet restore location). ASCOM DLLs were not CopyLocal'd to `bin/Debug/`, causing
`ReflectionTypeLoadException` at COM activation on a clean build.

**Build Fix 5 — Debug build targets wrong CPU architecture**
Debug `PropertyGroup` had `<PlatformTarget>AnyCPU</PlatformTarget>`. On 64-bit Windows this
wrote the COM registration to the 64-bit registry hive; 32-bit ASCOM clients (N.I.N.A., SGP,
etc.) look in `Wow6432Node` and couldn't find the driver. Changed to `x86` to match the
Release configuration and the official installer.

> **Note for maintainers:** The Release configuration already uses `x86` and is unaffected.
> If your release pipeline generates Debug as an intermediate artifact, or if you prefer a
> different mechanism for ensuring 32-bit registration in Debug builds, please review this
> change. The core requirement is that `LocalServer32` lands in `Wow6432Node`.

---

## Test Environment
- Hardware: BTT SKR Pico v1.0, firmware V1.13.9
- ASCOM Platform 6.6, ASCOM driver v6.6.6.8
- N.I.N.A. 3.x (ASCOM telescope client)
- OATControl (WPF desktop app, WiFi + serial)
- Windows 11
