### PR TITLE
Add GitHub release update checker

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -71,7 +71,7 @@ Update these two files:
 - Change two.
 ```
 
-**`OATControl/README.txt`** — Plain text format matching existing entries. Use the exact column alignment pattern:
+**`OATControl/Readme.txt`** — Plain text format matching existing entries. Use the exact column alignment pattern:
 ```
 OATControl V$VERSION                                         $DATE
 - One-line change.
@@ -81,7 +81,7 @@ The date format is `%d %b %Y` (e.g. `24 May 2026`). The header line is 65 charac
 
 ## Step 4: Commit & Tag
 
-1. Stage only the changed files: `AssemblyInfo.cs`, `OATControl Setup.iss`, `CHANGELOG.md`, `README.txt`
+1. Stage only the changed files: `AssemblyInfo.cs`, `OATControl Setup.iss`, `CHANGELOG.md`, `Readme.txt`
 2. Commit: `git commit -m "Release $TAG"`
 3. Tag: `git tag -a $TAG -m "Release $TAG"`
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,96 @@
+---
+name: release
+description: Use when the user wants to create a release, make a release, ship, cut a release, or publish a new version of OATControl. Triggers on phrases like "make a release", "let's ship", "let's release", "create a release", "ship it", "cut a release", "new release", "/release".
+---
+
+# OATControl Release
+
+Create a new OATControl release. Follow these steps in order. Stop and ask the user before proceeding if any step fails.
+
+## Pre-flight
+
+1. Verify `gh` CLI is available and authenticated (`gh auth status`)
+2. Verify git working tree is clean (`git status`)
+3. If either fails, stop and tell the user what to fix
+
+## Step 1: Version
+
+1. Read current version from `OATControl/Properties/AssemblyInfo.cs` line 54: `[assembly: AssemblyVersion("X.Y.Z.W")]`
+2. Show the current version to the user
+3. Propose the next version by bumping the minor segment (e.g. `1.2.0.0` → `1.3.0.0`)
+4. Ask the user to confirm or provide a different version
+5. Validate the new version is strictly higher than the current version
+6. Store as `$VERSION` (e.g. `1.3.0.0`) and `$TAG` (e.g. `V1.3.0.0`)
+
+## Step 2: Version Bump
+
+Update these two files:
+
+**`OATControl/Properties/AssemblyInfo.cs`** — Update both lines:
+```
+[assembly: AssemblyVersion("$VERSION")]
+[assembly: AssemblyFileVersion("$VERSION")]
+```
+
+**`OATControl/OATControl Setup.iss`** — Update line 5:
+```
+#define MyAppVersion "$VERSION"
+```
+
+## Step 3: Changelog + README
+
+1. Get the last release tag: `git tag --sort=-v:refname | grep -E '^V1\.' | head -1`
+2. Get commits since that tag: `git log $LAST_TAG..HEAD --oneline`
+3. Generate bullet points from the commit messages (combine related commits, make them concise)
+4. Present the bullet list to the user for editing
+5. Once approved, prepend to both files:
+
+**`OATControl/CHANGELOG.md`** — Markdown format:
+```markdown
+## OATControl V$VERSION ($DATE)
+
+- Change one.
+- Change two.
+```
+
+**`OATControl/README.txt`** — Plain text format matching existing entries. Use the exact column alignment pattern:
+```
+OATControl V$VERSION                                         $DATE
+- One-line change.
+- Another change.
+```
+The date format is `%d %b %Y` (e.g. `24 May 2026`). The header line is 65 characters wide — pad with spaces so the date aligns to the right edge.
+
+## Step 4: Commit & Tag
+
+1. Stage only the changed files: `AssemblyInfo.cs`, `OATControl Setup.iss`, `CHANGELOG.md`, `README.txt`
+2. Commit: `git commit -m "Release $TAG"`
+3. Tag: `git tag -a $TAG -m "Release $TAG"`
+
+## Step 5: Build Pause
+
+Tell the user:
+
+> **Build required.** Please do the following in Visual Studio:
+> 1. Build OATControl in **Release** mode
+> 2. Run **InnoSetup** on `OATControl/OATControl Setup.iss`
+> 3. Confirm when done
+
+Wait for the user to confirm, then verify the installer exists at `OATControl/bin/SetupOutput/OATControlSetup.exe`. If not found, ask the user to check.
+
+## Step 6: Push & GitHub Draft Release
+
+1. Push: `git push && git push --tags`
+2. Create a temporary file with the changelog bullet points (just the bullets, no header) for release notes
+3. Create draft release:
+   ```
+   gh release create $TAG --draft --title "$TAG" --notes-file <temp-file> "OATControl/bin/SetupOutput/OATControlSetup.exe"
+   ```
+4. Report the draft release URL to the user
+5. Clean up the temporary notes file
+
+## Error Handling
+
+- If any step fails, report the error clearly and stop
+- Do not attempt partial recovery or skip steps
+- The user can fix the issue and re-run `/release` from the beginning, or continue manually

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -14,23 +14,6 @@ Create a new OATControl release. Follow these steps in order. Stop and ask the u
 3. Verify git working tree is clean (`git status`)
 4. If either fails, stop and tell the user what to fix
 
-## Step 0: Verify Master Branch
-
-Releases must always be cut from `master`. Check and handle the current branch:
-
-1. Check current branch: `git branch --show-current`
-2. If already on `master`, proceed to Step 1
-3. If on a feature branch:
-   - Check if an open PR exists: `gh pr list --head <branch> --state open`
-   - If no PR exists, offer to create one: `gh pr create --base master --head <branch> --title "<title>" --body "<body>"`
-   - If PR is open, tell the user to merge it first and stop
-   - If PR exists but is not merged, tell the user to merge it first and stop
-4. After confirming the PR is merged, switch to master and pull:
-   ```
-   git checkout master && git pull
-   ```
-5. Proceed to Step 1
-
 ## Step 1: Version
 
 1. Read current version from `OATControl/Properties/AssemblyInfo.cs` line 54: `[assembly: AssemblyVersion("X.Y.Z.W")]`
@@ -55,7 +38,7 @@ Update these two files:
 #define MyAppVersion "$VERSION"
 ```
 
-## Step 3: Changelog + README
+## Step 3: Changelog + Readme
 
 1. Get the last release tag: `git tag --sort=-v:refname | grep -E '^V1\.' | head -1`
 2. Get commits since that tag: `git log $LAST_TAG..HEAD --oneline`
@@ -79,13 +62,34 @@ OATControl V$VERSION                                         $DATE
 ```
 The date format is `%d %b %Y` (e.g. `24 May 2026`). The header line is 65 characters wide — pad with spaces so the date aligns to the right edge.
 
-## Step 4: Commit & Tag
+## Step 4: Commit
 
 1. Stage only the changed files: `AssemblyInfo.cs`, `OATControl Setup.iss`, `CHANGELOG.md`, `Readme.txt`
 2. Commit: `git commit -m "Release $TAG"`
-3. Tag: `git tag -a $TAG -m "Release $TAG"`
+3. Push the commit to the remote branch
 
-## Step 5: Build Pause
+## Step 5: Create or Update PR
+
+1. Check if an open PR exists: `gh pr list --head <branch> --state open`
+2. If no PR exists, create one with the release changes included in the description
+3. If PR already exists, it's now updated with the release files
+4. Tell the user to **merge the PR** and wait for confirmation
+
+## Step 6: Switch to Master
+
+After the PR is merged:
+
+1. Switch to master and pull the merge:
+   ```
+   git checkout master && git pull
+   ```
+2. Tag the merge commit:
+   ```
+   git tag -a $TAG -m "Release $TAG"
+   ```
+3. Push the tag: `git push --tags`
+
+## Step 7: Build Pause
 
 Tell the user:
 
@@ -96,18 +100,17 @@ Tell the user:
 
 Wait for the user to confirm, then verify the installer exists at `OATControl/bin/SetupOutput/OATControlSetup.exe`. If not found, ask the user to check.
 
-## Step 6: Push & GitHub Draft Release
+## Step 8: GitHub Draft Release
 
-1. Push: `git push && git push --tags`
-2. Create a temporary file with the changelog bullet points (just the bullets, no header) for release notes
-3. Create draft release:
+1. Create a temporary file with the changelog bullet points (just the bullets, no header) for release notes
+2. Create draft release:
    ```
    gh release create $TAG --draft --title "OATControl $TAG Release" --notes-file <temp-file> "OATControl/bin/SetupOutput/OATControlSetup.exe"
    ```
-4. Report the draft release URL to the user
-5. Clean up the temporary notes file
+3. Report the draft release URL to the user
+4. Clean up the temporary notes file
 
-## Step 7: Discord Announcement
+## Step 9: Discord Announcement
 
 1. Read the webhook URL from `.claude/settings.local.json` key `discordReleaseWebhook`
 2. If the key is missing, ask the user for the webhook URL and save it to `.claude/settings.local.json`
@@ -123,7 +126,7 @@ Wait for the user to confirm, then verify the installer exists at `OATControl/bi
    OpenAstroTech Team
    $RELEASE_URL
    ```
-   Use the same user-facing bullet points from Step 3. The `$RELEASE_URL` is the GitHub release URL from Step 6.
+   Use the same user-facing bullet points from Step 3. The `$RELEASE_URL` is the GitHub release URL from Step 8.
 4. POST to the webhook:
    ```bash
    curl -X POST "$WEBHOOK_URL" \

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -10,8 +10,26 @@ Create a new OATControl release. Follow these steps in order. Stop and ask the u
 ## Pre-flight
 
 1. Verify `gh` CLI is available and authenticated (`gh auth status`)
-2. Verify git working tree is clean (`git status`)
-3. If either fails, stop and tell the user what to fix
+2. Verify `curl` is available (`which curl`)
+3. Verify git working tree is clean (`git status`)
+4. If either fails, stop and tell the user what to fix
+
+## Step 0: Verify Master Branch
+
+Releases must always be cut from `master`. Check and handle the current branch:
+
+1. Check current branch: `git branch --show-current`
+2. If already on `master`, proceed to Step 1
+3. If on a feature branch:
+   - Check if an open PR exists: `gh pr list --head <branch> --state open`
+   - If no PR exists, offer to create one: `gh pr create --base master --head <branch> --title "<title>" --body "<body>"`
+   - If PR is open, tell the user to merge it first and stop
+   - If PR exists but is not merged, tell the user to merge it first and stop
+4. After confirming the PR is merged, switch to master and pull:
+   ```
+   git checkout master && git pull
+   ```
+5. Proceed to Step 1
 
 ## Step 1: Version
 
@@ -84,10 +102,35 @@ Wait for the user to confirm, then verify the installer exists at `OATControl/bi
 2. Create a temporary file with the changelog bullet points (just the bullets, no header) for release notes
 3. Create draft release:
    ```
-   gh release create $TAG --draft --title "$TAG" --notes-file <temp-file> "OATControl/bin/SetupOutput/OATControlSetup.exe"
+   gh release create $TAG --draft --title "OATControl $TAG Release" --notes-file <temp-file> "OATControl/bin/SetupOutput/OATControlSetup.exe"
    ```
 4. Report the draft release URL to the user
 5. Clean up the temporary notes file
+
+## Step 7: Discord Announcement
+
+1. Read the webhook URL from `.claude/settings.local.json` key `discordReleaseWebhook`
+2. If the key is missing, ask the user for the webhook URL and save it to `.claude/settings.local.json`
+3. Build the announcement message:
+   ```
+   @everyone A new OATControl version ($TAG) has been released. These are the main changes:
+
+   - Bullet one.
+   - Bullet two.
+
+   Let us know if there are any issues.
+
+   OpenAstroTech Team
+   $RELEASE_URL
+   ```
+   Use the same user-facing bullet points from Step 3. The `$RELEASE_URL` is the GitHub release URL from Step 6.
+4. POST to the webhook:
+   ```bash
+   curl -X POST "$WEBHOOK_URL" \
+     -H "Content-Type: application/json" \
+     -d '{"content": "<message with \\n for line breaks>"}'
+   ```
+5. Report success to the user
 
 ## Error Handling
 

--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,6 @@ MigrationBackup/
 SetupOutputTemp
 OATControl/OATControl Setup.exe
 ASCOM.Driver/OpenAstroTracker Setup.exe
+
+# Superpowers brainstorming
+.superpowers/

--- a/OATControl/CHANGELOG.md
+++ b/OATControl/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## V1.2.1.0
+
+### Update Checker
+
+- Automatic update checking for both desktop app and firmware.
+- Update notification dialog with themed markdown changelog and download with progress.
+- Firmware update badge on Mount Settings button and update link in Settings dialog.
+- "Skip This Version" option to suppress notifications for a specific release.
+- "Check For Updates" button in App Settings with inline result display.
+- Update checks throttled to once per 24 hours; manual check bypasses throttle.
+- Fault-tolerant — all network calls are fire-and-forget with 5-second timeouts.
+
 ## V1.2.0.0
 
 ### MahApps.Metro Removal

--- a/OATControl/DlgAppSettings.xaml
+++ b/OATControl/DlgAppSettings.xaml
@@ -393,6 +393,14 @@
 								Style="{StaticResource MainButtonStyle}" x:Name="EditThemeButton"/>
 					</StackPanel>
 
+					<StackPanel Grid.Row="4" Grid.Column="0" VerticalAlignment="Top" Margin="8,12,0,0">
+						<TextBlock Text="Software Updates" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+						<TextBlock Text="Check GitHub for a newer version of OATControl." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+					</StackPanel>
+					<Button Grid.Row="4" Grid.Column="1" Content="Check For Updates" Width="130" Height="24"
+							Margin="10,22,58,0" HorizontalAlignment="Left" VerticalAlignment="Top"
+							Style="{StaticResource MainButtonStyle}" Click="OnCheckForUpdates" x:Name="CheckForUpdatesButton"/>
+
 				</Grid>
 			</TabItem>
 			<TabItem Header="Autohoming">

--- a/OATControl/DlgAppSettings.xaml
+++ b/OATControl/DlgAppSettings.xaml
@@ -12,88 +12,88 @@
 		Loaded="OnWindowLoaded"
 		mc:Ignorable="d"
         Title="OATControl Settings" MinHeight="400" Width="660" MinWidth="600" Height="560" WindowStyle="ToolWindow">
-	<Window.Resources>
-		<converters:DoubleToHMSConverter x:Key="RAConverter" />
-		<converters:DoubleToHMSConverter x:Key="DECConverter" Formatter = "[0:+00;-00]° [1:00]&quot; [2:00]'"/>
-		<converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" Collapse="True" />
-		<Style x:Key="CategoryItem" TargetType="ListViewItem" BasedOn="{StaticResource MetroListBoxItem}" >
-			<Setter Property="FontWeight" Value="Bold" />
-			<Setter Property="FontSize" Value="14" />
-			<Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}" />
-			<Setter Property="Background" Value="Transparent" />
-			<Setter Property="BorderBrush" Value="Transparent" />
-			<Setter Property="BorderThickness" Value="1" />
-			<Setter Property="FocusVisualStyle" Value="{x:Null}" />
-			<Setter Property="Template">
-				<Setter.Value>
-					<ControlTemplate TargetType="ListViewItem">
-						<Border x:Name="Bd"
+    <Window.Resources>
+        <converters:DoubleToHMSConverter x:Key="RAConverter" />
+        <converters:DoubleToHMSConverter x:Key="DECConverter" Formatter = "[0:+00;-00]° [1:00]&quot; [2:00]'"/>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" Collapse="True" />
+        <Style x:Key="CategoryItem" TargetType="ListViewItem" BasedOn="{StaticResource MetroListBoxItem}" >
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListViewItem">
+                        <Border x:Name="Bd"
 								Background="{TemplateBinding Background}"
 								BorderBrush="{TemplateBinding BorderBrush}"
 								BorderThickness="{TemplateBinding BorderThickness}"
 								Padding="{TemplateBinding Padding}"
 								SnapsToDevicePixels="True">
-							<TextBlock Text="{Binding Content, RelativeSource={RelativeSource TemplatedParent}}"
-									   FontSize="{TemplateBinding FontSize}"
-									   FontWeight="{TemplateBinding FontWeight}"
-									   Foreground="{TemplateBinding Foreground}"
-									   HorizontalAlignment="Left" VerticalAlignment="Center" />
-						</Border>
-						<ControlTemplate.Triggers>
-							<MultiTrigger>
-								<MultiTrigger.Conditions>
-									<Condition Property="IsMouseOver" Value="True" />
-									<Condition Property="IsSelected" Value="False" />
-								</MultiTrigger.Conditions>
-								<Setter TargetName="Bd" Property="Background" Value="{DynamicResource AppButtonHoverBrush}" />
-								<Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource AppButtonBorderBrush}" />
-							</MultiTrigger>
-							<Trigger Property="IsSelected" Value="True">
-								<Setter TargetName="Bd" Property="Background" Value="{DynamicResource AppButtonHoverBrush}" />
-								<Setter Property="Foreground" Value="{DynamicResource AppForegroundAccentBrush}" />
-								<Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource AppBorderBrush}" />
-							</Trigger>
-						</ControlTemplate.Triggers>
-					</ControlTemplate>
-				</Setter.Value>
-			</Setter>
-		</Style>
-		<Style x:Key="ComboBoxStyle" TargetType="ComboBox">
-			<Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}" />
-			<Setter Property="FontWeight" Value="Bold" />
-			<Setter Property="Background" Value="{DynamicResource AppButtonBackgroundBrush}" />
-			<Setter Property="BorderBrush" Value="{DynamicResource AppButtonHoverBrush}" />
-			<Setter Property="FontSize" Value="14" />
-			<Setter Property="HorizontalAlignment" Value="Left" />
-			<Setter Property="FocusVisualStyle" Value="{x:Null}" />
-			<Setter Property="Template">
-				<Setter.Value>
-					<ControlTemplate TargetType="ComboBox">
-						<Grid>
-							<Border x:Name="MainBorder"
+                            <TextBlock Text="{Binding Content, RelativeSource={RelativeSource TemplatedParent}}"
+								FontSize="{TemplateBinding FontSize}"
+								FontWeight="{TemplateBinding FontWeight}"
+								Foreground="{TemplateBinding Foreground}"
+								HorizontalAlignment="Left" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsMouseOver" Value="True" />
+                                    <Condition Property="IsSelected" Value="False" />
+                                </MultiTrigger.Conditions>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AppButtonHoverBrush}" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource AppButtonBorderBrush}" />
+                            </MultiTrigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AppButtonHoverBrush}" />
+                                <Setter Property="Foreground" Value="{DynamicResource AppForegroundAccentBrush}" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource AppBorderBrush}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Style x:Key="ComboBoxStyle" TargetType="ComboBox">
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Background" Value="{DynamicResource AppButtonBackgroundBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource AppButtonHoverBrush}" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ComboBox">
+                        <Grid>
+                            <Border x:Name="MainBorder"
 									Background="{TemplateBinding Background}"
 									BorderBrush="{TemplateBinding BorderBrush}"
 									BorderThickness="1"
 									CornerRadius="2">
-								<Grid>
-									<ToggleButton x:Name="ToggleButton"
+                                <Grid>
+                                    <ToggleButton x:Name="ToggleButton"
 													  Focusable="False"
 													  ClickMode="Press"
 													  IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
-										<ToggleButton.Template>
-											<ControlTemplate TargetType="ToggleButton">
-												<Border Background="Transparent" />
-											</ControlTemplate>
-										</ToggleButton.Template>
-									</ToggleButton>
-									<ContentPresenter x:Name="ContentSite"
+                                        <ToggleButton.Template>
+                                            <ControlTemplate TargetType="ToggleButton">
+                                                <Border Background="Transparent" />
+                                            </ControlTemplate>
+                                        </ToggleButton.Template>
+                                    </ToggleButton>
+                                    <ContentPresenter x:Name="ContentSite"
 														  Content="{TemplateBinding SelectionBoxItem}"
 														  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
 														  ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
 														  Margin="6,2,20,2"
 														  HorizontalAlignment="Left"
 														  VerticalAlignment="Center" />
-									<Path x:Name="Arrow"
+                                    <Path x:Name="Arrow"
 												  Data="M0,0 L4,4 8,0"
 												  Stroke="{DynamicResource AppForegroundBrush}"
 												  StrokeThickness="1.5"
@@ -102,143 +102,143 @@
 												  VerticalAlignment="Center"
 												  Margin="0,0,6,0"
 												  Stretch="Uniform" />
-								</Grid>
-							</Border>
-							<Popup x:Name="PART_Popup"
+                                </Grid>
+                            </Border>
+                            <Popup x:Name="PART_Popup"
 								   IsOpen="{TemplateBinding IsDropDownOpen}"
 								   Placement="Bottom"
 								   PopupAnimation="Slide"
 								   AllowsTransparency="True">
-								<Border Background="{DynamicResource AppButtonBackgroundBrush}"
+                                <Border Background="{DynamicResource AppButtonBackgroundBrush}"
 										BorderBrush="{TemplateBinding BorderBrush}"
 										BorderThickness="1"
 										CornerRadius="2"
 										MinWidth="{TemplateBinding ActualWidth}"
 										MaxHeight="{TemplateBinding MaxDropDownHeight}">
-									<ScrollViewer>
-										<StackPanel IsItemsHost="True" />
-									</ScrollViewer>
-								</Border>
-							</Popup>
-						</Grid>
-						<ControlTemplate.Triggers>
-							<Trigger Property="IsMouseOver" Value="True">
-								<Setter TargetName="MainBorder" Property="Background" Value="{DynamicResource AppButtonHoverBrush}" />
-							</Trigger>
-							<Trigger Property="IsDropDownOpen" Value="True">
-								<Setter TargetName="MainBorder" Property="Background" Value="{DynamicResource AppButtonPressedBrush}" />
-							</Trigger>
-							<Trigger Property="IsEnabled" Value="False">
-								<Setter TargetName="MainBorder" Property="Background" Value="{DynamicResource AppDisabledBackgroundBrush}" />
-								<Setter TargetName="MainBorder" Property="BorderBrush" Value="{DynamicResource AppDisabledBorderBrush}" />
-							</Trigger>
-						</ControlTemplate.Triggers>
-					</ControlTemplate>
-				</Setter.Value>
-			</Setter>
-			<Setter Property="ItemContainerStyle">
-				<Setter.Value>
-					<Style TargetType="ComboBoxItem">
-						<Setter Property="Background" Value="{DynamicResource AppButtonBackgroundBrush}" />
-						<Setter Property="BorderBrush" Value="{DynamicResource AppBorderBrush}" />
-						<Setter Property="BorderThickness" Value="1" />
-						<Setter Property="Padding" Value="4" />
-						<Setter Property="Template">
-							<Setter.Value>
-								<ControlTemplate TargetType="ComboBoxItem">
-									<Border x:Name="Bd"
+                                    <ScrollViewer>
+                                        <StackPanel IsItemsHost="True" />
+                                    </ScrollViewer>
+                                </Border>
+                            </Popup>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="MainBorder" Property="Background" Value="{DynamicResource AppButtonHoverBrush}" />
+                            </Trigger>
+                            <Trigger Property="IsDropDownOpen" Value="True">
+                                <Setter TargetName="MainBorder" Property="Background" Value="{DynamicResource AppButtonPressedBrush}" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="MainBorder" Property="Background" Value="{DynamicResource AppDisabledBackgroundBrush}" />
+                                <Setter TargetName="MainBorder" Property="BorderBrush" Value="{DynamicResource AppDisabledBorderBrush}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="ItemContainerStyle">
+                <Setter.Value>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="Background" Value="{DynamicResource AppButtonBackgroundBrush}" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource AppBorderBrush}" />
+                        <Setter Property="BorderThickness" Value="1" />
+                        <Setter Property="Padding" Value="4" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ComboBoxItem">
+                                    <Border x:Name="Bd"
 											Background="{TemplateBinding Background}"
 											BorderBrush="{TemplateBinding BorderBrush}"
 											BorderThickness="{TemplateBinding BorderThickness}"
 											Padding="{TemplateBinding Padding}"
 											CornerRadius="1">
-										<ContentPresenter />
-									</Border>
-									<ControlTemplate.Triggers>
-										<Trigger Property="IsHighlighted" Value="True">
-											<Setter TargetName="Bd" Property="Background" Value="{DynamicResource AppButtonHoverBrush}" />
-										</Trigger>
-										<Trigger Property="IsSelected" Value="True">
-											<Setter TargetName="Bd" Property="Background" Value="{DynamicResource AppButtonHoverBrush}" />
-											<Setter Property="Foreground" Value="{DynamicResource AppForegroundStrongBrush}" />
-										</Trigger>
-									</ControlTemplate.Triggers>
-								</ControlTemplate>
-							</Setter.Value>
-						</Setter>
-					</Style>
-				</Setter.Value>
-			</Setter>
-		</Style>
+                                        <ContentPresenter />
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsHighlighted" Value="True">
+                                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AppButtonHoverBrush}" />
+                                        </Trigger>
+                                        <Trigger Property="IsSelected" Value="True">
+                                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource AppButtonHoverBrush}" />
+                                            <Setter Property="Foreground" Value="{DynamicResource AppForegroundStrongBrush}" />
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </Setter.Value>
+            </Setter>
+        </Style>
 
-		<Style x:Key="TextBoxSmallLimit" TargetType="TextBox" BasedOn="{StaticResource MetroTextBox}" >
-			<Setter Property="Margin" Value="5,2" />
-			<Setter Property="Height" Value="24" />
-			<Setter Property="Background" Value="{DynamicResource AppButtonBackgroundBrush}" />
-			<Setter Property="Foreground" Value="{DynamicResource AppForegroundStrongBrush}" />
-			<Setter Property="Width" Value="50" />
-			<Setter Property="HorizontalContentAlignment" Value="Center"/>
-		</Style>
-		<Style x:Key="TextBoxSmall" TargetType="TextBox" BasedOn="{StaticResource MetroTextBox}" >
-			<Setter Property="Margin" Value="10,2,10,2" />
-			<Setter Property="Height" Value="24" />
-			<Setter Property="Background" Value="{DynamicResource AppButtonBackgroundBrush}" />
-			<Setter Property="Foreground" Value="{DynamicResource AppForegroundStrongBrush}" />
-			<Setter Property="Width" Value="60" />
-			<Setter Property="HorizontalAlignment" Value="Left"/>
-		</Style>
-		<Style x:Key="TextBlockLabel" TargetType="TextBlock" BasedOn="{StaticResource MetroTextBlock}">
-			<Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}" />
-			<Setter Property="FontWeight" Value="Bold" />
-			<Setter Property="FontSize" Value="14" />
-			<Setter Property="Margin" Value="0,8,0,0" />
-			<Setter Property="Padding" Value="2,0" />
-			<Setter Property="HorizontalAlignment" Value="Left" />
-		</Style>
-		<Style x:Key="TextBlockOptionHelp" TargetType="TextBlock" BasedOn="{StaticResource MetroTextBlock}">
-			<Setter Property="FontSize" Value="10" />
-			<Setter Property="FontWeight" Value="Normal" />
-			<Setter Property="TextWrapping" Value="Wrap" />
-			<Setter Property="Width" Value="Auto" />
-			<Setter Property="Margin" Value="2,0,20,0" />
-			<Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}" />
-		</Style>
+        <Style x:Key="TextBoxSmallLimit" TargetType="TextBox" BasedOn="{StaticResource MetroTextBox}" >
+            <Setter Property="Margin" Value="5,2" />
+            <Setter Property="Height" Value="24" />
+            <Setter Property="Background" Value="{DynamicResource AppButtonBackgroundBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundStrongBrush}" />
+            <Setter Property="Width" Value="50" />
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        </Style>
+        <Style x:Key="TextBoxSmall" TargetType="TextBox" BasedOn="{StaticResource MetroTextBox}" >
+            <Setter Property="Margin" Value="10,2,10,2" />
+            <Setter Property="Height" Value="24" />
+            <Setter Property="Background" Value="{DynamicResource AppButtonBackgroundBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundStrongBrush}" />
+            <Setter Property="Width" Value="60" />
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+        </Style>
+        <Style x:Key="TextBlockLabel" TargetType="TextBlock" BasedOn="{StaticResource MetroTextBlock}">
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="Margin" Value="0,8,0,0" />
+            <Setter Property="Padding" Value="2,0" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+        </Style>
+        <Style x:Key="TextBlockOptionHelp" TargetType="TextBlock" BasedOn="{StaticResource MetroTextBlock}">
+            <Setter Property="FontSize" Value="10" />
+            <Setter Property="FontWeight" Value="Normal" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+            <Setter Property="Width" Value="Auto" />
+            <Setter Property="Margin" Value="2,0,20,0" />
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}" />
+        </Style>
 
-		<Style x:Key="TextBlockOptionHelpNoWidth" TargetType="TextBlock" BasedOn="{StaticResource MetroTextBlock}">
-			<Setter Property="FontSize" Value="9" />
-			<Setter Property="FontWeight" Value="Normal" />
-			<Setter Property="TextWrapping" Value="Wrap" />
-			<Setter Property="Margin" Value="2,0,0,0" />
-			<Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}" />
-		</Style>
+        <Style x:Key="TextBlockOptionHelpNoWidth" TargetType="TextBlock" BasedOn="{StaticResource MetroTextBlock}">
+            <Setter Property="FontSize" Value="9" />
+            <Setter Property="FontWeight" Value="Normal" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+            <Setter Property="Margin" Value="2,0,0,0" />
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundBrush}" />
+        </Style>
 
-		<Style x:Key="TextBlockDescription" TargetType="TextBlock" BasedOn="{StaticResource TextBlockLabel}">
-			<Setter Property="FontSize" Value="10" />
-			<Setter Property="FontWeight" Value="Normal" />
-			<Setter Property="Margin" Value="0,0,0,0" />
-			<Setter Property="Padding" Value="2,0" />
-			<Setter Property="HorizontalAlignment" Value="Left" />
-			<Setter Property="VerticalAlignment" Value="Top" />
-		</Style>
+        <Style x:Key="TextBlockDescription" TargetType="TextBlock" BasedOn="{StaticResource TextBlockLabel}">
+            <Setter Property="FontSize" Value="10" />
+            <Setter Property="FontWeight" Value="Normal" />
+            <Setter Property="Margin" Value="0,0,0,0" />
+            <Setter Property="Padding" Value="2,0" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+        </Style>
 
-		<Style x:Key="GridViewColumnHeaderStyle1" TargetType="{x:Type GridViewColumnHeader}">
-			<Setter Property="Template">
-				<Setter.Value>
-					<ControlTemplate TargetType="{x:Type GridViewColumnHeader}">
-						<Border BorderThickness="0,0,0,1" BorderBrush="{DynamicResource AppBorderBrush}" >
-							<StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-								<Border Background="Transparent">
-									<TextBlock x:Name="ContentHeader" 
+        <Style x:Key="GridViewColumnHeaderStyle1" TargetType="{x:Type GridViewColumnHeader}">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type GridViewColumnHeader}">
+                        <Border BorderThickness="0,0,0,1" BorderBrush="{DynamicResource AppBorderBrush}" >
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <Border Background="Transparent">
+                                    <TextBlock x:Name="ContentHeader" 
 										   Text="{TemplateBinding Content}" 
 										   Padding="1,5,1,1" 
 										   Margin="0,0,4,0"
 										   FontSize="11"
 										   Width="{TemplateBinding Width}" 
 										   />
-								</Border>
+                                </Border>
 
-								<!-- Sort indicator: a simple arrow -->
-								<Path x:Name="SortArrow" 
+                                <!-- Sort indicator: a simple arrow -->
+                                <Path x:Name="SortArrow" 
 									  Width="6" 
 									  Height="6" 
 									  Stretch="Fill" 
@@ -248,103 +248,103 @@
 									  Visibility="Hidden" 
 									  RenderTransformOrigin="0.5,0.25"
 									  />
-							</StackPanel>
-						</Border>
-					</ControlTemplate>
-				</Setter.Value>
-			</Setter>
-			<!--<Setter Property="BorderBrush" Value="{DynamicResource AppBorderBrush}"/>
+                            </StackPanel>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <!--<Setter Property="BorderBrush" Value="{DynamicResource AppBorderBrush}"/>
 			<Setter Property="Background" Value="{DynamicResource AppButtonBackgroundBrush}"/>
 			<Setter Property="OverridesDefaultStyle" Value="True" />-->
-			<Setter Property="Foreground" Value="{DynamicResource AppForegroundStrongBrush}" />
-			<Setter Property="FontFamily" Value="Segoe UI" />
-			<Setter Property="FontSize" Value="14" />
-			<Setter Property="FontWeight" Value="Bold" />
-		</Style>
+            <Setter Property="Foreground" Value="{DynamicResource AppForegroundStrongBrush}" />
+            <Setter Property="FontFamily" Value="Segoe UI" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="FontWeight" Value="Bold" />
+        </Style>
 
-		<DataTemplate x:Key="NameCellTemplate">
-			<TextBlock Padding="5,0" FontWeight="Bold">
-				<TextBlock.Text>
-					<Binding Path="Name" />
-				</TextBlock.Text>
-			</TextBlock>
-		</DataTemplate>
-		<DataTemplate x:Key="CatalogNameCellTemplate">
-			<TextBlock Padding="5,0" HorizontalAlignment="Center">
-				<TextBlock.Text>
-					<Binding Path="CatalogName" />
-				</TextBlock.Text>
-			</TextBlock>
-		</DataTemplate>
-		<DataTemplate x:Key="EnabledCellTemplate">
-			<CheckBox Padding="5,0" >
-				<CheckBox.IsChecked>
-					<Binding Path="Enabled" Mode="TwoWay" />
-				</CheckBox.IsChecked>
-			</CheckBox>
-		</DataTemplate>
-		<DataTemplate x:Key="RaCellTemplate">
-			<TextBlock Padding="3,0" HorizontalAlignment="Center">
-				<TextBlock.Text>
-					<Binding Path="RA" Converter="{StaticResource RAConverter}"/>
-				</TextBlock.Text>
-			</TextBlock>
-		</DataTemplate>
-		<DataTemplate x:Key="DecCellTemplate">
-			<TextBlock Padding="1,0">
-				<TextBlock.Text>
-					<Binding Path="DEC" Converter="{StaticResource DECConverter}"/>
-				</TextBlock.Text>
-			</TextBlock>
-		</DataTemplate>
-		<ObjectDataProvider ObjectType="{x:Type localVM:ChecklistShowOnEnumHelper}" MethodName="get_ChecklistShowOnValues" x:Key="ChecklistShowOnValues"/>
-	</Window.Resources>
-	<DockPanel Margin="8">
-		<!-- Close Button -->
-		<StackPanel DockPanel.Dock="Bottom" HorizontalAlignment="Right" Orientation="Horizontal" Margin="0,8,0,0">
-			<Button Content="Ok" Width="80" HorizontalAlignment="Right" Click="OnCloseClick" Style="{StaticResource MainButtonStyle}" Margin="0,0,8,0"/>
-			<Button Content="Cancel" Width="80" HorizontalAlignment="Right" Click="OnCloseCancelClick" Style="{StaticResource MainButtonStyle}"/>
-		</StackPanel>
+        <DataTemplate x:Key="NameCellTemplate">
+            <TextBlock Padding="5,0" FontWeight="Bold">
+                <TextBlock.Text>
+                    <Binding Path="Name" />
+                </TextBlock.Text>
+            </TextBlock>
+        </DataTemplate>
+        <DataTemplate x:Key="CatalogNameCellTemplate">
+            <TextBlock Padding="5,0" HorizontalAlignment="Center">
+                <TextBlock.Text>
+                    <Binding Path="CatalogName" />
+                </TextBlock.Text>
+            </TextBlock>
+        </DataTemplate>
+        <DataTemplate x:Key="EnabledCellTemplate">
+            <CheckBox Padding="5,0" >
+                <CheckBox.IsChecked>
+                    <Binding Path="Enabled" Mode="TwoWay" />
+                </CheckBox.IsChecked>
+            </CheckBox>
+        </DataTemplate>
+        <DataTemplate x:Key="RaCellTemplate">
+            <TextBlock Padding="3,0" HorizontalAlignment="Center">
+                <TextBlock.Text>
+                    <Binding Path="RA" Converter="{StaticResource RAConverter}"/>
+                </TextBlock.Text>
+            </TextBlock>
+        </DataTemplate>
+        <DataTemplate x:Key="DecCellTemplate">
+            <TextBlock Padding="1,0">
+                <TextBlock.Text>
+                    <Binding Path="DEC" Converter="{StaticResource DECConverter}"/>
+                </TextBlock.Text>
+            </TextBlock>
+        </DataTemplate>
+        <ObjectDataProvider ObjectType="{x:Type localVM:ChecklistShowOnEnumHelper}" MethodName="get_ChecklistShowOnValues" x:Key="ChecklistShowOnValues"/>
+    </Window.Resources>
+    <DockPanel Margin="8">
+        <!-- Close Button -->
+        <StackPanel DockPanel.Dock="Bottom" HorizontalAlignment="Right" Orientation="Horizontal" Margin="0,8,0,0">
+            <Button Content="Ok" Width="80" HorizontalAlignment="Right" Click="OnCloseClick" Style="{StaticResource MainButtonStyle}" Margin="0,0,8,0"/>
+            <Button Content="Cancel" Width="80" HorizontalAlignment="Right" Click="OnCloseCancelClick" Style="{StaticResource MainButtonStyle}"/>
+        </StackPanel>
 
-		<!-- Category Selector ListView -->
-		<Border Margin="4,2,12,1">
-			<ListView Name="CategorySelector" DockPanel.Dock="Left" Width="120" SelectionChanged="OnCategorySelected" Background="{DynamicResource AppNestedBackgroundBrush}">
-				<ListViewItem Content="General" Style="{StaticResource CategoryItem}"/>
-				<ListViewItem Content="Autohoming" Style="{StaticResource CategoryItem}"/>
-				<ListViewItem Content="Target List" Style="{StaticResource CategoryItem}"/>
-				<ListViewItem Content="Auto PA" Style="{StaticResource CategoryItem}"/>
-			</ListView>
-		</Border>
-		<!-- TabControl to host different views. Hide the headers so it just shows the content. -->
-		<TabControl Name="ContentTabs" TabStripPlacement="Top" IsTabStop="False"  Margin="0,0,0,1" >
-			<TabControl.ItemContainerStyle>
-				<Style TargetType="TabItem">
-					<Setter Property="Visibility" Value="Collapsed"/>
-				</Style>
-			</TabControl.ItemContainerStyle>
+        <!-- Category Selector ListView -->
+        <Border Margin="4,2,12,1">
+            <ListView Name="CategorySelector" DockPanel.Dock="Left" Width="120" SelectionChanged="OnCategorySelected" Background="{DynamicResource AppNestedBackgroundBrush}">
+                <ListViewItem Content="General" Style="{StaticResource CategoryItem}"/>
+                <ListViewItem Content="Autohoming" Style="{StaticResource CategoryItem}"/>
+                <ListViewItem Content="Target List" Style="{StaticResource CategoryItem}"/>
+                <ListViewItem Content="Auto PA" Style="{StaticResource CategoryItem}"/>
+            </ListView>
+        </Border>
+        <!-- TabControl to host different views. Hide the headers so it just shows the content. -->
+        <TabControl Name="ContentTabs" TabStripPlacement="Top" IsTabStop="False"  Margin="0,0,0,1" >
+            <TabControl.ItemContainerStyle>
+                <Style TargetType="TabItem">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                </Style>
+            </TabControl.ItemContainerStyle>
 
-			<TabItem Header="General">
-				<!--     GENERAL     -->
-				<Grid Background="{DynamicResource AppNestedBackgroundBrush}" Margin="-2">
-					<Grid.RowDefinitions>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-					</Grid.RowDefinitions>
-					<Grid.ColumnDefinitions>
-						<ColumnDefinition Width="*" />
-						<ColumnDefinition Width="Auto" />
-					</Grid.ColumnDefinitions>
+            <TabItem Header="General">
+                <!--     GENERAL     -->
+                <Grid Background="{DynamicResource AppNestedBackgroundBrush}" Margin="-2">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
 
-					<StackPanel Grid.Row="0" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,10">
-						<TextBlock Text="Baudrate" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-						<TextBlock Text="Speed at which to connect with OAT/OAM. Unless you have changed this in a custom build this should be 19200." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
-					</StackPanel>
-					<ComboBox Grid.Row="0" Grid.Column="1" 
+                    <StackPanel Grid.Row="0" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,10">
+                        <TextBlock Text="Baudrate" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                        <TextBlock Text="Speed at which to connect with OAT/OAM. Unless you have changed this in a custom build this should be 19200." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    </StackPanel>
+                    <ComboBox Grid.Row="0" Grid.Column="1" 
 							  ItemsSource="{Binding AvailableBaudRates}" 
 							  SelectedValue="{Binding SelectedBaudRate}"
 							  Width="120" 
@@ -353,12 +353,12 @@
 							  Style="{StaticResource ComboBoxStyle}" 
 					/>
 
-					<StackPanel Grid.Row="1" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,0">
-						<TextBlock Text="Checklist" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-						<TextBlock Text="When do you want the checklist to appear. " Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
-					</StackPanel>
-					<StackPanel Grid.Row="1" Grid.Column="1" Grid.RowSpan="1" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,4,20,0" Orientation="Horizontal">
-						<ComboBox
+                    <StackPanel Grid.Row="1" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,0">
+                        <TextBlock Text="Checklist" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                        <TextBlock Text="When do you want the checklist to appear. " Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    </StackPanel>
+                    <StackPanel Grid.Row="1" Grid.Column="1" Grid.RowSpan="1" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,4,20,0" Orientation="Horizontal">
+                        <ComboBox
           					  ItemsSource="{Binding Source={StaticResource ChecklistShowOnValues}}" 
 							  SelectedValue="{Binding ShowChecklist}"
 							  Width="130" 
@@ -367,17 +367,17 @@
 							  FontSize="14" 
 							  HorizontalAlignment="Left" 
 							  Style="{StaticResource ComboBoxStyle}"  />
-						<controls:IconButton HorizontalAlignment="Center" Width="28" Height="28"
+                        <controls:IconButton HorizontalAlignment="Center" Width="28" Height="28"
 							Margin="0,2,0,0"
 							Command="{Binding ConfigureChecklistCommand}" Padding="0" ToolTip="Configure the items on the checklist to display."
 							IconData="M16.000015,9.6000061C12.500012,9.6000061 9.5999844,12.5 9.5999844,16 9.5999844,19.5 12.500012,22.399994 16.000015,22.399994 19.500019,22.399994 22.400015,19.5 22.400015,16 22.400015,12.5 19.500019,9.6000061 16.000015,9.6000061z M14.199995,0L17.800005,0C18.199999,0,18.599993,0.29998779,18.599993,0.79998779L18.599993,4.7999878C19.900013,5.1000061,21.000019,5.6000061,22.099997,6.2999878L25.000023,3.3999939C25.099999,3.2999878 25.300011,3.1999817 25.500025,3.1999817 25.700007,3.1999817 25.900019,3.2999878 26.000025,3.3999939L28.600033,6C28.900021,6.2999878,28.900021,6.7999878,28.600033,7.1000061L25.700007,10C26.400019,11.100006,26.900019,12.299988,27.200007,13.5L31.20001,13.5C31.600037,13.5,31.999998,13.799988,31.999998,14.299988L31.999998,17.899994C31.999998,18.299988,31.700012,18.699982,31.20001,18.699982L27.200007,18.699982C26.900019,20,26.400019,21.100006,25.700007,22.199982L28.600033,25.100006C28.700009,25.199982 28.799984,25.399994 28.799984,25.600006 28.799984,25.799988 28.700009,26 28.600033,26.100006L26.000025,28.600006C25.900019,28.699982 25.700007,28.799988 25.500025,28.799988 25.300011,28.799988 25.099999,28.699982 25.000023,28.600006L22.099997,25.699982C21.000019,26.399994,19.800007,26.899994,18.599993,27.199982L18.599993,31.199982C18.599993,31.600006,18.300005,32,17.800005,32L14.199995,32C13.8,32,13.400006,31.699982,13.400006,31.199982L13.400006,27.199982C12.099987,26.899994,11.000011,26.399994,9.9000027,25.699982L7.0000064,28.600006C6.9000003,28.699982 6.6999881,28.799988 6.5000059,28.799988 6.2999937,28.799988 6.099981,28.699982 6.0000054,28.600006L3.3999967,26C3.0999784,25.699982,3.0999784,25.199982,3.3999967,24.899994L6.2999937,22C5.5999805,20.899994,5.0999801,19.699982,4.7999923,18.5L0.79998828,18.5C0.39999409,18.5,-1.933513E-07,18.199982,0,17.699982L0,14.100006C-1.933513E-07,13.699982,0.2999879,13.299988,0.79998828,13.299988L4.7999923,13.299988C5.0999801,12,5.5999805,10.899994,6.2999937,9.7999878L3.3999967,7C3.2999908,6.8999939 3.1999845,6.6999817 3.1999845,6.5 3.1999845,6.2999878 3.2999908,6.1000061 3.3999967,6L6.0000054,3.3999939C6.099981,3.2999878 6.2999937,3.1999817 6.5000059,3.1999817 6.6999881,3.1999817 6.9000003,3.2999878 7.0000064,3.3999939L9.9000027,6.2999878C11.000011,5.6000061,12.199993,5.1000061,13.400006,4.7999878L13.400006,0.79998779C13.400006,0.29998779,13.8,0,14.199995,0z" />
-					</StackPanel>
+                    </StackPanel>
 
-					<StackPanel Grid.Row="2" Grid.Column="0" VerticalAlignment="Top" Margin="8,12,0,0">
-						<TextBlock Text="Theme" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-						<TextBlock Text="Select the color theme for the application." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
-					</StackPanel>
-					<ComboBox Grid.Row="2" Grid.Column="1"
+                    <StackPanel Grid.Row="2" Grid.Column="0" VerticalAlignment="Top" Margin="8,12,0,0">
+                        <TextBlock Text="Theme" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                        <TextBlock Text="Select the color theme for the application." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    </StackPanel>
+                    <ComboBox Grid.Row="2" Grid.Column="1"
 						  DisplayMemberPath="DisplayName"
 						  SelectedValuePath="Id"
 						  x:Name="ThemeComboBox"
@@ -388,89 +388,94 @@
 						  SelectionChanged="ThemeComboBox_SelectionChanged"
 						  Style="{StaticResource ComboBoxStyle}" />
 
-					<StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="10,8,64,0" HorizontalAlignment="Right">
-						<Button Content="Manage Themes" Click="OnEditTheme" Width="120" Margin="0,0,4,0"
+                    <StackPanel Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="10,8,64,0" HorizontalAlignment="Right">
+                        <Button Content="Manage Themes" Click="OnEditTheme" Width="120" Margin="0,0,4,0"
 								Style="{StaticResource MainButtonStyle}" x:Name="EditThemeButton"/>
-					</StackPanel>
+                    </StackPanel>
 
-					<StackPanel Grid.Row="4" Grid.Column="0" VerticalAlignment="Top" Margin="8,12,0,0">
-						<TextBlock Text="Software Updates" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-						<TextBlock Text="Check GitHub for a newer version of OATControl." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
-					</StackPanel>
-					<Button Grid.Row="4" Grid.Column="1" Content="Check For Updates" Width="130" Height="24"
-							Margin="10,22,58,0" HorizontalAlignment="Left" VerticalAlignment="Top"
+                    <StackPanel Grid.Row="4" Grid.Column="0" VerticalAlignment="Top" Margin="8,12,0,0">
+                        <TextBlock Text="Software Updates" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                        <TextBlock Text="Check GitHub for a newer version of OATControl." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    </StackPanel>
+                    <StackPanel Grid.Row="4" Grid.Column="1" VerticalAlignment="Top" Margin="10,22,58,0">
+                        <Button Content="Check For Updates" Width="130" Height="24"
+							HorizontalAlignment="Left" VerticalAlignment="Top"
 							Style="{StaticResource MainButtonStyle}" Click="OnCheckForUpdates" x:Name="CheckForUpdatesButton"/>
+                        <TextBlock x:Name="UpdateCheckResultText" FontSize="10" Margin="0,4,0,0"
+							   Foreground="{DynamicResource AppForegroundBrush}" TextWrapping="Wrap"
+							   Visibility="Collapsed"/>
+                    </StackPanel>
 
-				</Grid>
-			</TabItem>
-			<TabItem Header="Autohoming">
-				<!--     AUTOHOMING  -->
-				<StackPanel Grid.Row="1" Grid.Column="1" Margin="-2" Background="{DynamicResource AppNestedBackgroundBrush}">
-					<Grid>
-						<Grid.RowDefinitions>
-							<RowDefinition Height="50"/>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="50"/>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="50"/>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="50"/>
-							<RowDefinition Height="Auto"/>
-						</Grid.RowDefinitions>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="*"/>
-						</Grid.ColumnDefinitions>
+                </Grid>
+            </TabItem>
+            <TabItem Header="Autohoming">
+                <!--     AUTOHOMING  -->
+                <StackPanel Grid.Row="1" Grid.Column="1" Margin="-2" Background="{DynamicResource AppNestedBackgroundBrush}">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="50"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="50"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="50"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="50"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
 
-						<StackPanel Grid.Row="0" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,0">
-							<TextBlock Text="RA Start Direction" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-							<TextBlock Text="Initial RA direction for autohoming to start searching for the Hall sensor." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top"/>
-						</StackPanel>
-						<StackPanel Grid.Row="0" Grid.Column="1" Grid.RowSpan="2" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,0,55,0">
-							<controls:LabeledToggleSwitch  Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,12,0,0" VerticalAlignment="Center" IsChecked="{Binding RaStartEast}" OnLabel="EAST" OffLabel="WEST" Width="64"/>
-						</StackPanel>
-						<StackPanel Grid.Row="2" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,0">
-							<TextBlock Text="RA Search Distance" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-							<TextBlock Text="Number of degrees to search for the Hall sensor in each direction." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top"/>
-						</StackPanel>
-						<StackPanel Grid.Row="2" Grid.Column="1" Grid.RowSpan="2"  Orientation="Horizontal" HorizontalAlignment="Right">
-							<TextBox Grid.Row="2" Grid.Column="1" Grid.RowSpan="2"  Style="{StaticResource TextBoxSmall}" Text="{Binding RaDistance}"/>
-							<TextBlock Grid.Row="2" Grid.Column="1" Grid.RowSpan="2"  Style="{StaticResource TextBlockDescription}" Text="degrees" VerticalAlignment="Center" Margin="0,0,8,0"/>
-						</StackPanel>
+                        <StackPanel Grid.Row="0" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,0">
+                            <TextBlock Text="RA Start Direction" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                            <TextBlock Text="Initial RA direction for autohoming to start searching for the Hall sensor." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top"/>
+                        </StackPanel>
+                        <StackPanel Grid.Row="0" Grid.Column="1" Grid.RowSpan="2" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,0,55,0">
+                            <controls:LabeledToggleSwitch  Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,12,0,0" VerticalAlignment="Center" IsChecked="{Binding RaStartEast}" OnLabel="EAST" OffLabel="WEST" Width="64"/>
+                        </StackPanel>
+                        <StackPanel Grid.Row="2" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,0">
+                            <TextBlock Text="RA Search Distance" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                            <TextBlock Text="Number of degrees to search for the Hall sensor in each direction." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top"/>
+                        </StackPanel>
+                        <StackPanel Grid.Row="2" Grid.Column="1" Grid.RowSpan="2"  Orientation="Horizontal" HorizontalAlignment="Right">
+                            <TextBox Grid.Row="2" Grid.Column="1" Grid.RowSpan="2"  Style="{StaticResource TextBoxSmall}" Text="{Binding RaDistance}"/>
+                            <TextBlock Grid.Row="2" Grid.Column="1" Grid.RowSpan="2"  Style="{StaticResource TextBlockDescription}" Text="degrees" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        </StackPanel>
 
-						<StackPanel Grid.Row="4" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,0">
-							<TextBlock Text="DEC Start Direction" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-							<TextBlock Text="Initial DEC direction for autohoming to start searching for the Hall sensor." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top"/>
-						</StackPanel>
-						<StackPanel Grid.Row="4" Grid.Column="1" Grid.RowSpan="2" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,12,45,8">
-							<controls:LabeledToggleSwitch  Grid.Row="0"  Grid.Column="0" Grid.ColumnSpan="3" Margin="0,0,0,0" VerticalAlignment="Center" IsChecked="{Binding DecStartSouth}" Width="72" OnLabel="SOUTH" OffLabel="NORTH"/>
-						</StackPanel>
-						<StackPanel Grid.Row="6" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,0">
-							<TextBlock Text="DEC Search Distance" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-							<TextBlock Text="Number of degrees to search for the Hall sensor in each direction." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top"/>
-						</StackPanel>
-						<StackPanel Grid.Row="6" Grid.Column="1" Grid.RowSpan="2"  Orientation="Horizontal" HorizontalAlignment="Right">
-							<TextBox Style="{StaticResource TextBoxSmall}" Text="{Binding DecDistance}" VerticalAlignment="Center"/>
-							<TextBlock Style="{StaticResource TextBlockDescription}" Text="degrees" VerticalAlignment="Center" Margin="0,0,8,0"/>
-						</StackPanel>
-					</Grid>
-				</StackPanel>
-			</TabItem>
-			<TabItem Header="Target List" >
-				<!--     TARGET LIST-->
-				<Grid Background="{DynamicResource AppNestedBackgroundBrush}">
-					<Grid.RowDefinitions>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="*"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-					</Grid.RowDefinitions>
-					<Grid.ColumnDefinitions>
-						<ColumnDefinition Width="*" />
-					</Grid.ColumnDefinitions>
+                        <StackPanel Grid.Row="4" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,0">
+                            <TextBlock Text="DEC Start Direction" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                            <TextBlock Text="Initial DEC direction for autohoming to start searching for the Hall sensor." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top"/>
+                        </StackPanel>
+                        <StackPanel Grid.Row="4" Grid.Column="1" Grid.RowSpan="2" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,12,45,8">
+                            <controls:LabeledToggleSwitch  Grid.Row="0"  Grid.Column="0" Grid.ColumnSpan="3" Margin="0,0,0,0" VerticalAlignment="Center" IsChecked="{Binding DecStartSouth}" Width="72" OnLabel="SOUTH" OffLabel="NORTH"/>
+                        </StackPanel>
+                        <StackPanel Grid.Row="6" Grid.Column="0" VerticalAlignment="Top" Margin="8,0,0,0">
+                            <TextBlock Text="DEC Search Distance" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                            <TextBlock Text="Number of degrees to search for the Hall sensor in each direction." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top"/>
+                        </StackPanel>
+                        <StackPanel Grid.Row="6" Grid.Column="1" Grid.RowSpan="2"  Orientation="Horizontal" HorizontalAlignment="Right">
+                            <TextBox Style="{StaticResource TextBoxSmall}" Text="{Binding DecDistance}" VerticalAlignment="Center"/>
+                            <TextBlock Style="{StaticResource TextBlockDescription}" Text="degrees" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        </StackPanel>
+                    </Grid>
+                </StackPanel>
+            </TabItem>
+            <TabItem Header="Target List" >
+                <!--     TARGET LIST-->
+                <Grid Background="{DynamicResource AppNestedBackgroundBrush}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-					<TextBlock Grid.Row="0" Grid.Column="0" Text="Manage the targets shown in the Target Chooser Dialog." Style="{StaticResource TextBlockOptionHelpNoWidth}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,5,0,10"/>
-					<ListView Grid.Row="1" Grid.Column="0" 
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Manage the targets shown in the Target Chooser Dialog." Style="{StaticResource TextBlockOptionHelpNoWidth}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,5,0,10"/>
+                    <ListView Grid.Row="1" Grid.Column="0" 
 							  x:Name="TargetsListView"
 							  ItemsSource="{Binding AllPointsOfInterest}" 
 							  HorizontalAlignment="Stretch" 
@@ -482,52 +487,52 @@
 							  GridViewColumnHeader.Click="OnHeaderClick"
 							  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
 							  ScrollViewer.ScrollChanged="OnTargetsListScrollChanged">
-						<ListView.View>
-							<GridView  ColumnHeaderContainerStyle="{StaticResource GridViewColumnHeaderStyle1}" >
-								<GridViewColumn Header="Show" Width="45" CellTemplate="{StaticResource EnabledCellTemplate}" />
-								<GridViewColumn Header="Catalog" Width="70" CellTemplate="{StaticResource CatalogNameCellTemplate}" />
-								<GridViewColumn Header="Name"  CellTemplate="{StaticResource NameCellTemplate}" />
-								<GridViewColumn Header="RA"  Width="80" CellTemplate="{StaticResource RaCellTemplate}"/>
-								<GridViewColumn Header="DEC"  Width="90"  CellTemplate="{StaticResource DecCellTemplate}"/>
-							</GridView>
-						</ListView.View>
-					</ListView>
-					<StackPanel Grid.Row="2" Grid.Column="0" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,10" Orientation="Horizontal" >
-						<Button Content="Edit Target" Command="{Binding EditPointCommand}" Style="{StaticResource MainButtonStyle}" VerticalAlignment="Top" Width="90" Margin="10,0" IsEnabled="{Binding IsPointSelected}"/>
-						<Button Content="Add Target" Command="{Binding AddPointCommand}" Style="{StaticResource MainButtonStyle}" VerticalAlignment="Top" Width="90"/>
-					</StackPanel>
-				</Grid>
-			</TabItem>
-			<TabItem Header="Auto PA" >
-				<!--     AUTO  PA  -->
-				<Grid Background="{DynamicResource AppNestedBackgroundBrush}" Margin="-2">
-					<Grid.RowDefinitions>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-						<RowDefinition Height="Auto"/>
-					</Grid.RowDefinitions>
-					<Grid.ColumnDefinitions>
-						<ColumnDefinition Width="*" />
-						<ColumnDefinition Width="Auto" />
-					</Grid.ColumnDefinitions>
+                        <ListView.View>
+                            <GridView  ColumnHeaderContainerStyle="{StaticResource GridViewColumnHeaderStyle1}" >
+                                <GridViewColumn Header="Show" Width="45" CellTemplate="{StaticResource EnabledCellTemplate}" />
+                                <GridViewColumn Header="Catalog" Width="70" CellTemplate="{StaticResource CatalogNameCellTemplate}" />
+                                <GridViewColumn Header="Name"  CellTemplate="{StaticResource NameCellTemplate}" />
+                                <GridViewColumn Header="RA"  Width="80" CellTemplate="{StaticResource RaCellTemplate}"/>
+                                <GridViewColumn Header="DEC"  Width="90"  CellTemplate="{StaticResource DecCellTemplate}"/>
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+                    <StackPanel Grid.Row="2" Grid.Column="0" VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,10" Orientation="Horizontal" >
+                        <Button Content="Edit Target" Command="{Binding EditPointCommand}" Style="{StaticResource MainButtonStyle}" VerticalAlignment="Top" Width="90" Margin="10,0" IsEnabled="{Binding IsPointSelected}"/>
+                        <Button Content="Add Target" Command="{Binding AddPointCommand}" Style="{StaticResource MainButtonStyle}" VerticalAlignment="Top" Width="90"/>
+                    </StackPanel>
+                </Grid>
+            </TabItem>
+            <TabItem Header="Auto PA" >
+                <!--     AUTO  PA  -->
+                <Grid Background="{DynamicResource AppNestedBackgroundBrush}" Margin="-2">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
 
-					<StackPanel Grid.Row="0" Grid.Column="0" VerticalAlignment="Top"  Margin="8,0,0,0">
-						<TextBlock Text="Monitor N.I.N.A. for TPPA" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-						<TextBlock Text="If enabled, this will monitor N.I.N.A. and automatically run Polar Alignment adjustments as needed." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
-					</StackPanel>
-					<controls:LabeledToggleSwitch  Grid.Row="0"  Grid.Column="1" Grid.ColumnSpan="3" Margin="5,0,20,0" VerticalAlignment="Center" IsChecked="{Binding MonitorNinaForPA}" OnLabel="YES" OffLabel="No" Width="56"/>
-					<StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Top" Margin="20,0,0,0" 
+                    <StackPanel Grid.Row="0" Grid.Column="0" VerticalAlignment="Top"  Margin="8,0,0,0">
+                        <TextBlock Text="Monitor N.I.N.A. for TPPA" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                        <TextBlock Text="If enabled, this will monitor N.I.N.A. and automatically run Polar Alignment adjustments as needed." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    </StackPanel>
+                    <controls:LabeledToggleSwitch  Grid.Row="0"  Grid.Column="1" Grid.ColumnSpan="3" Margin="5,0,20,0" VerticalAlignment="Center" IsChecked="{Binding MonitorNinaForPA}" OnLabel="YES" OffLabel="No" Width="56"/>
+                    <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Top" Margin="20,0,0,0" 
 								Visibility="{Binding MonitorNinaForPA, Converter={StaticResource BoolToVisibilityConverter}}">
-						<TextBlock Text="N.I.N.A. Log folder" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" />
-						<TextBlock Text="The log folder of N.I.N.A. to monitor for Polar Alignment. Only N.I.N.A. V3.1 and later is supported." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Stretch" Width="Auto" />
-					</StackPanel>
-					<TextBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" 
+                        <TextBlock Text="N.I.N.A. Log folder" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" />
+                        <TextBlock Text="The log folder of N.I.N.A. to monitor for Polar Alignment. Only N.I.N.A. V3.1 and later is supported." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Stretch" Width="Auto" />
+                    </StackPanel>
+                    <TextBox Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" 
 							Visibility="{Binding MonitorNinaForPA, Converter={StaticResource BoolToVisibilityConverter}}"
 							Style="{StaticResource TextBoxSmall}" 
 							Width="Auto"
@@ -535,29 +540,29 @@
 							Text="{Binding NinaLogFolder}" 
 							VerticalAlignment="Center" Margin="20,4,20,0"/>
 
-					<StackPanel Grid.Row="3" Grid.Column="0" VerticalAlignment="Top" Margin="8,20,0,0">
-						<TextBlock Text="Monitor SharpCap for PA" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-						<TextBlock Text="If enabled, this will monitor SharpCap and automatically run Polar Alignment adjustments as needed." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
-					</StackPanel>
-					<controls:LabeledToggleSwitch  Grid.Row="3"  Grid.Column="1" Grid.ColumnSpan="3" Margin="5,0,20,0" VerticalAlignment="Center" IsChecked="{Binding MonitorSharpCapForPA}" OnLabel="YES" OffLabel="No" Width="56"/>
-					<Grid Grid.Row="3"  Grid.Column="1" Width="Auto" HorizontalAlignment="Left"  Margin="0,32,0,0">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto" />
-							<RowDefinition Height="Auto" />
-						</Grid.RowDefinitions>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="40" />
-							<ColumnDefinition Width="*" />
-							<ColumnDefinition Width="40" />
-						</Grid.ColumnDefinitions>
-					</Grid>
-					<StackPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Top" Margin="20,0,0,0"
+                    <StackPanel Grid.Row="3" Grid.Column="0" VerticalAlignment="Top" Margin="8,20,0,0">
+                        <TextBlock Text="Monitor SharpCap for PA" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                        <TextBlock Text="If enabled, this will monitor SharpCap and automatically run Polar Alignment adjustments as needed." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    </StackPanel>
+                    <controls:LabeledToggleSwitch  Grid.Row="3"  Grid.Column="1" Grid.ColumnSpan="3" Margin="5,0,20,0" VerticalAlignment="Center" IsChecked="{Binding MonitorSharpCapForPA}" OnLabel="YES" OffLabel="No" Width="56"/>
+                    <Grid Grid.Row="3"  Grid.Column="1" Width="Auto" HorizontalAlignment="Left"  Margin="0,32,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="40" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="40" />
+                        </Grid.ColumnDefinitions>
+                    </Grid>
+                    <StackPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Top" Margin="20,0,0,0"
 								Visibility="{Binding MonitorSharpCapForPA, Converter={StaticResource BoolToVisibilityConverter}}">
-						<TextBlock Text="SharpCap Log folder" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" />
-						<TextBlock Text="The log folder of SharpCap to monitor for Polar Alignment. Only SharpCap 4.x and later is supported." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Stretch" Width="Auto" />
-					</StackPanel>
+                        <TextBlock Text="SharpCap Log folder" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" />
+                        <TextBlock Text="The log folder of SharpCap to monitor for Polar Alignment. Only SharpCap 4.x and later is supported." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Stretch" Width="Auto" />
+                    </StackPanel>
 
-					<TextBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" 
+                    <TextBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" 
 							Visibility="{Binding MonitorSharpCapForPA, Converter={StaticResource BoolToVisibilityConverter}}"
 							Style="{StaticResource TextBoxSmall}" 
 							Width="Auto"
@@ -565,59 +570,59 @@
 							Text="{Binding SharpCapLogFolder}" 
 							VerticalAlignment="Center" Margin="20,4,20,0"/>
 
-					<StackPanel Grid.Row="6" Grid.Column="0" VerticalAlignment="Top"  Margin="8,15,0,0">
-						<TextBlock Text="Invert corrections" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-						<TextBlock Text="If enabled, the corrections for the corresponding axis will be inverted." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
-					</StackPanel>
+                    <StackPanel Grid.Row="6" Grid.Column="0" VerticalAlignment="Top"  Margin="8,15,0,0">
+                        <TextBlock Text="Invert corrections" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                        <TextBlock Text="If enabled, the corrections for the corresponding axis will be inverted." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    </StackPanel>
 
-					<Grid Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2" >
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="Auto"/>
-						</Grid.RowDefinitions>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="*" />
-							<ColumnDefinition Width="Auto" />
-							<ColumnDefinition Width="Auto" />
-						</Grid.ColumnDefinitions>
-						<TextBlock Grid.Column="1" Text="AZ" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" Margin="20,20,0,0" HorizontalAlignment="Left"/>
-						<TextBlock Grid.Column="2" Text="ALT" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" Margin="20,20,0,0" HorizontalAlignment="Left"/>
-						<controls:LabeledToggleSwitch  Grid.Row="0"  Grid.Column="1" Margin="5,40,20,0" VerticalAlignment="Center" IsChecked="{Binding InvertAZCorrections}" OnLabel="YES" OffLabel="NO"/>
-						<controls:LabeledToggleSwitch  Grid.Row="0"  Grid.Column="2"  Margin="5,40,20,0" VerticalAlignment="Center" IsChecked="{Binding InvertALTCorrections}"  OnLabel="YES" OffLabel="NO"/>
-					</Grid>
+                    <Grid Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2" >
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="1" Text="AZ" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" Margin="20,20,0,0" HorizontalAlignment="Left"/>
+                        <TextBlock Grid.Column="2" Text="ALT" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" Margin="20,20,0,0" HorizontalAlignment="Left"/>
+                        <controls:LabeledToggleSwitch  Grid.Row="0"  Grid.Column="1" Margin="5,40,20,0" VerticalAlignment="Center" IsChecked="{Binding InvertAZCorrections}" OnLabel="YES" OffLabel="NO"/>
+                        <controls:LabeledToggleSwitch  Grid.Row="0"  Grid.Column="2"  Margin="5,40,20,0" VerticalAlignment="Center" IsChecked="{Binding InvertALTCorrections}"  OnLabel="YES" OffLabel="NO"/>
+                    </Grid>
 
-					<StackPanel Grid.Row="7" Grid.Column="0" VerticalAlignment="Top"  Margin="8,12,0,0">
-						<TextBlock Text="AZ/ALT axis limits" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-						<TextBlock Text="Determines the maximum angle in degrees that the AZ and ALT axes will be moved during Automatic Polar Alignment." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
-					</StackPanel>
+                    <StackPanel Grid.Row="7" Grid.Column="0" VerticalAlignment="Top"  Margin="8,12,0,0">
+                        <TextBlock Text="AZ/ALT axis limits" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                        <TextBlock Text="Determines the maximum angle in degrees that the AZ and ALT axes will be moved during Automatic Polar Alignment." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    </StackPanel>
 
-					<Grid Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="2" HorizontalAlignment="Left" Margin="0,12,0,0">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="Auto"/>
-						</Grid.RowDefinitions>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="*" />
-							<ColumnDefinition Width="*" />
-						</Grid.ColumnDefinitions>
-						<TextBlock Grid.Row="0" Grid.Column="0" Text="AZ Limits" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0,5,20,0"/>
-						<TextBox Grid.Row="1" Grid.Column="0" Text="{Binding AZLimit}" HorizontalAlignment="Left" Style="{StaticResource TextBoxSmallLimit}" />
-						<TextBlock Grid.Row="0" Grid.Column="1" Text="ALT Limits" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0,5,20,0"/>
-						<TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ALTLimit}" HorizontalAlignment="Left" Style="{StaticResource TextBoxSmallLimit}" />
+                    <Grid Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="2" HorizontalAlignment="Left" Margin="0,12,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="AZ Limits" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0,5,20,0"/>
+                        <TextBox Grid.Row="1" Grid.Column="0" Text="{Binding AZLimit}" HorizontalAlignment="Left" Style="{StaticResource TextBoxSmallLimit}" />
+                        <TextBlock Grid.Row="0" Grid.Column="1" Text="ALT Limits" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0,5,20,0"/>
+                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ALTLimit}" HorizontalAlignment="Left" Style="{StaticResource TextBoxSmallLimit}" />
 
-					</Grid>
+                    </Grid>
 
-					<StackPanel Grid.Row="8" Grid.Column="0" VerticalAlignment="Top"  Margin="8,12,0,0">
-						<TextBlock Text="Minimum Total Error" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
-						<TextBlock Text="If Alignment Tolerance in N.I.N.A is set to zero, polar alignment does not terminate automatically. This value determines at which Total Error value OATControl will assume alignment has been reached and will no longer issue corrections." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
-					</StackPanel>
+                    <StackPanel Grid.Row="8" Grid.Column="0" VerticalAlignment="Top"  Margin="8,12,0,0">
+                        <TextBlock Text="Minimum Total Error" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top"/>
+                        <TextBlock Text="If Alignment Tolerance in N.I.N.A is set to zero, polar alignment does not terminate automatically. This value determines at which Total Error value OATControl will assume alignment has been reached and will no longer issue corrections." Style="{StaticResource TextBlockOptionHelp}" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    </StackPanel>
 
-					<StackPanel Grid.Row="8" Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal">
-						<TextBox Text="{Binding PolarAlignmentMinimumTotalError}" HorizontalAlignment="Left" Style="{StaticResource TextBoxSmallLimit}" />
-						<TextBlock Text="arc seconds" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0,5,20,0"/>
-					</StackPanel>
+                    <StackPanel Grid.Row="8" Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal">
+                        <TextBox Text="{Binding PolarAlignmentMinimumTotalError}" HorizontalAlignment="Left" Style="{StaticResource TextBoxSmallLimit}" />
+                        <TextBlock Text="arc seconds" Style="{StaticResource TextBlockLabel}" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0,5,20,0"/>
+                    </StackPanel>
 
-					<!--<Grid Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="2" HorizontalAlignment="Left">
+                    <!--<Grid Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="2" HorizontalAlignment="Left">
 						<Grid.RowDefinitions>
 							<RowDefinition Height="Auto"/>
 							<RowDefinition Height="Auto"/>
@@ -631,10 +636,10 @@
 
 					</Grid>-->
 
-				</Grid>
-			</TabItem>
-		</TabControl>
-	</DockPanel>
+                </Grid>
+            </TabItem>
+        </TabControl>
+    </DockPanel>
 </controls:ThemedWindow>
 	
 	

--- a/OATControl/DlgAppSettings.xaml.cs
+++ b/OATControl/DlgAppSettings.xaml.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -535,6 +536,32 @@ namespace OATControl
 				AppSettings.Instance.ThemeName = themeId;
 				AppSettings.Instance.Save();
 			}
+		}
+
+		private void OnCheckForUpdates(object sender, RoutedEventArgs e)
+		{
+			CheckForUpdatesButton.IsEnabled = false;
+			CheckForUpdatesButton.Content = "Checking...";
+
+			_ = Task.Run(() => UpdateChecker.CheckForDesktopUpdateAsync())
+				.ContinueWith(t =>
+				{
+					Dispatcher.Invoke(() =>
+					{
+						CheckForUpdatesButton.IsEnabled = true;
+						CheckForUpdatesButton.Content = "Check For Updates";
+
+						if (!t.IsFaulted && !t.IsCanceled && t.Result?.UpdateAvailable == true)
+						{
+							var dlg = new DlgUpdateAvailable(t.Result) { Owner = this, WindowStartupLocation = WindowStartupLocation.CenterOwner };
+							dlg.ShowDialog();
+						}
+						else
+						{
+							MessageBox.Show(this, "You are running the latest version of OATControl.", "No Updates Available", MessageBoxButton.OK, MessageBoxImage.Information);
+						}
+					});
+				});
 		}
 
 		private void OnEditTheme(object sender, RoutedEventArgs e)

--- a/OATControl/DlgAppSettings.xaml.cs
+++ b/OATControl/DlgAppSettings.xaml.cs
@@ -542,6 +542,8 @@ namespace OATControl
 		{
 			CheckForUpdatesButton.IsEnabled = false;
 			CheckForUpdatesButton.Content = "Checking...";
+			UpdateCheckResultText.Visibility = Visibility.Collapsed;
+			UpdateChecker.ResetDesktopCheckTimer();
 
 			_ = Task.Run(() => UpdateChecker.CheckForDesktopUpdateAsync())
 				.ContinueWith(t =>
@@ -556,9 +558,15 @@ namespace OATControl
 							var dlg = new DlgUpdateAvailable(t.Result) { Owner = this, WindowStartupLocation = WindowStartupLocation.CenterOwner };
 							dlg.ShowDialog();
 						}
+						else if (t.IsFaulted || t.IsCanceled)
+						{
+							UpdateCheckResultText.Text = "Could not check for updates.";
+							UpdateCheckResultText.Visibility = Visibility.Visible;
+						}
 						else
 						{
-							MessageBox.Show(this, "You are running the latest version of OATControl.", "No Updates Available", MessageBoxButton.OK, MessageBoxImage.Information);
+							UpdateCheckResultText.Text = "You are running the latest version.";
+							UpdateCheckResultText.Visibility = Visibility.Visible;
 						}
 					});
 				});

--- a/OATControl/DlgUpdateAvailable.xaml
+++ b/OATControl/DlgUpdateAvailable.xaml
@@ -33,7 +33,7 @@
                     VerticalAlignment="Center" Margin="0,0,0,12">
             <TextBlock Text="Downloading update..." Margin="0,0,0,8"
                        Foreground="{DynamicResource AppForegroundBrush}"/>
-            <ProgressBar Value="{Binding DownloadProgress}" Height="20" Minimum="0" Maximum="100"/>
+            <ProgressBar Value="{Binding DownloadProgress}" Height="20" Minimum="0" Maximum="100" Foreground="{DynamicResource AppForegroundStrongBrush}" BorderBrush="{DynamicResource AppButtonHoverBrush}" BorderThickness="1"/>
             <TextBlock Text="{Binding DownloadStatus}" Margin="0,4,0,0" HorizontalAlignment="Center"
                        Foreground="{DynamicResource AppForegroundBrush}"/>
         </StackPanel>
@@ -43,6 +43,10 @@
                    VerticalAlignment="Center" HorizontalAlignment="Center"/>
 
         <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Skip This Version" Height="28" Margin="0,0,8,0"
+                    Style="{StaticResource MainButtonStyle}"
+                    Command="{Binding SkipVersionCommand}"
+                    Visibility="{Binding IsDownloading, Converter={StaticResource InvertBoolToCollapsed}}"/>
             <Button Content="Skip" Width="80" Height="28" Margin="0,0,8,0"
                     Style="{StaticResource MainButtonStyle}"
                     Command="{Binding SkipCommand}"

--- a/OATControl/DlgUpdateAvailable.xaml
+++ b/OATControl/DlgUpdateAvailable.xaml
@@ -1,0 +1,60 @@
+<controls:ThemedWindow x:Class="OATControl.DlgUpdateAvailable"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:controls="clr-namespace:OATControl.Controls"
+        xmlns:converters="clr-namespace:OATControl.Converters"
+        mc:Ignorable="d"
+        Title="Update Available" Height="420" Width="500"
+        ResizeMode="NoResize"
+        controls:ThemedWindow.TitleBarButtons="Close">
+    <controls:ThemedWindow.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVisible" Collapse="False"/>
+        <converters:BoolToVisibilityConverter x:Key="InvertBoolToCollapsed" Collapse="True" IsReversed="True"/>
+    </controls:ThemedWindow.Resources>
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="{Binding VersionInfo}" FontWeight="Bold" FontSize="14"
+                   Foreground="{DynamicResource AppForegroundBrush}" Margin="0,0,0,12" TextWrapping="Wrap"/>
+
+        <TextBox Grid.Row="1" Text="{Binding Changelog}" IsReadOnly="True" TextWrapping="Wrap"
+                 VerticalScrollBarVisibility="Auto" AcceptsReturn="True"
+                 Padding="8" Margin="0,0,0,12"
+                 Visibility="{Binding IsDownloading, Converter={StaticResource InvertBoolToCollapsed}}"/>
+
+        <StackPanel Grid.Row="1" Visibility="{Binding IsDownloading, Converter={StaticResource BoolToVisible}}"
+                    VerticalAlignment="Center" Margin="0,0,0,12">
+            <TextBlock Text="Downloading update..." Margin="0,0,0,8"
+                       Foreground="{DynamicResource AppForegroundBrush}"/>
+            <ProgressBar Value="{Binding DownloadProgress}" Height="20" Minimum="0" Maximum="100"/>
+            <TextBlock Text="{Binding DownloadStatus}" Margin="0,4,0,0" HorizontalAlignment="Center"
+                       Foreground="{DynamicResource AppForegroundBrush}"/>
+        </StackPanel>
+
+        <TextBlock Grid.Row="1" Text="{Binding ErrorMessage}" Foreground="Red" TextWrapping="Wrap"
+                   Visibility="{Binding HasError, Converter={StaticResource BoolToVisible}}"
+                   VerticalAlignment="Center" HorizontalAlignment="Center"/>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Skip" Width="80" Height="28" Margin="0,0,8,0"
+                    Style="{StaticResource MainButtonStyle}"
+                    Command="{Binding SkipCommand}"
+                    Visibility="{Binding IsDownloading, Converter={StaticResource InvertBoolToCollapsed}}"/>
+            <Button Content="Cancel" Width="80" Height="28" Margin="0,0,8,0"
+                    Style="{StaticResource MainButtonStyle}"
+                    Command="{Binding CancelCommand}"
+                    Visibility="{Binding IsDownloading, Converter={StaticResource BoolToVisible}}"/>
+            <Button Content="Upgrade" Width="80" Height="28"
+                    Style="{StaticResource MainButtonStyle}"
+                    Command="{Binding UpgradeCommand}"
+                    Visibility="{Binding IsDownloading, Converter={StaticResource InvertBoolToCollapsed}}"/>
+        </StackPanel>
+    </Grid>
+</controls:ThemedWindow>

--- a/OATControl/DlgUpdateAvailable.xaml
+++ b/OATControl/DlgUpdateAvailable.xaml
@@ -5,6 +5,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:controls="clr-namespace:OATControl.Controls"
         xmlns:converters="clr-namespace:OATControl.Converters"
+        xmlns:mdxaml="clr-namespace:MdXaml;assembly=MdXaml"
         mc:Ignorable="d"
         Title="Update Available" Height="420" Width="500"
         ResizeMode="NoResize"
@@ -24,9 +25,8 @@
         <TextBlock Grid.Row="0" Text="{Binding VersionInfo}" FontWeight="Bold" FontSize="14"
                    Foreground="{DynamicResource AppForegroundBrush}" Margin="0,0,0,12" TextWrapping="Wrap"/>
 
-        <TextBox Grid.Row="1" Text="{Binding Changelog, Mode=OneWay}" IsReadOnly="True" TextWrapping="Wrap"
-                 VerticalScrollBarVisibility="Auto" AcceptsReturn="True"
-                 Padding="8" Margin="0,0,0,12"
+        <mdxaml:MarkdownScrollViewer Grid.Row="1" Markdown="{Binding Changelog, Mode=OneWay}"
+                 Margin="0,0,0,12"
                  Visibility="{Binding IsDownloading, Converter={StaticResource InvertBoolToCollapsed}}"/>
 
         <StackPanel Grid.Row="1" Visibility="{Binding IsDownloading, Converter={StaticResource BoolToVisible}}"

--- a/OATControl/DlgUpdateAvailable.xaml
+++ b/OATControl/DlgUpdateAvailable.xaml
@@ -25,7 +25,7 @@
         <TextBlock Grid.Row="0" Text="{Binding VersionInfo}" FontWeight="Bold" FontSize="14"
                    Foreground="{DynamicResource AppForegroundBrush}" Margin="0,0,0,12" TextWrapping="Wrap"/>
 
-        <mdxaml:MarkdownScrollViewer Grid.Row="1" Markdown="{Binding Changelog, Mode=OneWay}"
+        <mdxaml:MarkdownScrollViewer x:Name="MarkdownViewer" Grid.Row="1" Markdown="{Binding Changelog, Mode=OneWay}"
                  Margin="0,0,0,12"
                  Visibility="{Binding IsDownloading, Converter={StaticResource InvertBoolToCollapsed}}"/>
 

--- a/OATControl/DlgUpdateAvailable.xaml
+++ b/OATControl/DlgUpdateAvailable.xaml
@@ -24,7 +24,7 @@
         <TextBlock Grid.Row="0" Text="{Binding VersionInfo}" FontWeight="Bold" FontSize="14"
                    Foreground="{DynamicResource AppForegroundBrush}" Margin="0,0,0,12" TextWrapping="Wrap"/>
 
-        <TextBox Grid.Row="1" Text="{Binding Changelog}" IsReadOnly="True" TextWrapping="Wrap"
+        <TextBox Grid.Row="1" Text="{Binding Changelog, Mode=OneWay}" IsReadOnly="True" TextWrapping="Wrap"
                  VerticalScrollBarVisibility="Auto" AcceptsReturn="True"
                  Padding="8" Margin="0,0,0,12"
                  Visibility="{Binding IsDownloading, Converter={StaticResource InvertBoolToCollapsed}}"/>

--- a/OATControl/DlgUpdateAvailable.xaml.cs
+++ b/OATControl/DlgUpdateAvailable.xaml.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Documents;
+using System.Windows.Media;
 using MdXaml;
 using OATCommunications.WPF;
 
@@ -38,6 +39,16 @@ namespace OATControl
             var themedStyle = new Style(typeof(FlowDocument), MarkdownStyle.Standard);
             themedStyle.Setters.Add(new Setter(FlowDocument.ForegroundProperty, FindResource("AppForegroundBrush")));
             themedStyle.Setters.Add(new Setter(FlowDocument.BackgroundProperty, Brushes.Transparent));
+
+            themedStyle.Resources = new ResourceDictionary();
+            var foreground = FindResource("AppForegroundBrush");
+            foreach (var key in new[] { "H1", "H2", "H3", "H4", "H5", "H6" })
+            {
+                var hs = new Style(typeof(Paragraph));
+                hs.Setters.Add(new Setter(Paragraph.ForegroundProperty, foreground));
+                themedStyle.Resources[key] = hs;
+            }
+
             MarkdownViewer.MarkdownStyle = themedStyle;
 
             _skipCommand = new DelegateCommand(s => Close());

--- a/OATControl/DlgUpdateAvailable.xaml.cs
+++ b/OATControl/DlgUpdateAvailable.xaml.cs
@@ -1,0 +1,153 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using OATCommunications.WPF;
+
+namespace OATControl
+{
+    public partial class DlgUpdateAvailable : Controls.ThemedWindow, INotifyPropertyChanged
+    {
+        private readonly UpdateCheckResult _result;
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private bool _isDownloading;
+        private int _downloadProgress;
+        private string _downloadStatus;
+        private bool _hasError;
+        private string _errorMessage;
+        private DelegateCommand _skipCommand;
+        private DelegateCommand _upgradeCommand;
+        private DelegateCommand _cancelCommand;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public DlgUpdateAvailable(UpdateCheckResult result)
+        {
+            _result = result;
+            this.Owner = Application.Current.MainWindow;
+            this.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            InitializeComponent();
+            this.DataContext = this;
+
+            _skipCommand = new DelegateCommand(s => Close());
+            _upgradeCommand = new DelegateCommand(s => StartDownload());
+            _cancelCommand = new DelegateCommand(s => CancelDownload());
+        }
+
+        public string VersionInfo => $"OATControl {_result.LatestVersion} is now available (you have {_result.CurrentVersion})";
+        public string Changelog => _result.Changelog;
+
+        public bool IsDownloading
+        {
+            get => _isDownloading;
+            set { _isDownloading = value; OnPropertyChanged(nameof(IsDownloading)); }
+        }
+
+        public int DownloadProgress
+        {
+            get => _downloadProgress;
+            set { _downloadProgress = value; OnPropertyChanged(nameof(DownloadProgress)); }
+        }
+
+        public string DownloadStatus
+        {
+            get => _downloadStatus;
+            set { _downloadStatus = value; OnPropertyChanged(nameof(DownloadStatus)); }
+        }
+
+        public bool HasError
+        {
+            get => _hasError;
+            set { _hasError = value; OnPropertyChanged(nameof(HasError)); }
+        }
+
+        public string ErrorMessage
+        {
+            get => _errorMessage;
+            set { _errorMessage = value; OnPropertyChanged(nameof(ErrorMessage)); }
+        }
+
+        public System.Windows.Input.ICommand SkipCommand => _skipCommand;
+        public System.Windows.Input.ICommand UpgradeCommand => _upgradeCommand;
+        public System.Windows.Input.ICommand CancelCommand => _cancelCommand;
+
+        private async void StartDownload()
+        {
+            if (string.IsNullOrEmpty(_result.DownloadUrl))
+            {
+                HasError = true;
+                ErrorMessage = "No download URL available.";
+                return;
+            }
+
+            IsDownloading = true;
+            HasError = false;
+
+            try
+            {
+                var tempPath = Path.Combine(Path.GetTempPath(), "OATControlSetup.exe");
+
+                using (var client = new HttpClient { Timeout = TimeSpan.FromMinutes(5) })
+                using (var response = await client.GetAsync(_result.DownloadUrl, HttpCompletionOption.ResponseHeadersRead, _cts.Token))
+                {
+                    response.EnsureSuccessStatusCode();
+                    var totalBytes = response.Content.Headers.ContentLength ?? -1L;
+
+                    using (var stream = await response.Content.ReadAsStreamAsync())
+                    using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                    {
+                        var buffer = new byte[8192];
+                        long bytesRead = 0;
+                        int read;
+
+                        while ((read = await stream.ReadAsync(buffer, 0, buffer.Length, _cts.Token)) > 0)
+                        {
+                            await fileStream.WriteAsync(buffer, 0, read, _cts.Token);
+                            bytesRead += read;
+
+                            if (totalBytes > 0)
+                            {
+                                var progress = (int)(bytesRead * 100 / totalBytes);
+                                DownloadProgress = progress;
+                                DownloadStatus = $"{bytesRead / 1024} KB / {totalBytes / 1024} KB ({progress}%)";
+                            }
+                            else
+                            {
+                                DownloadStatus = $"{bytesRead / 1024} KB downloaded";
+                            }
+                        }
+                    }
+
+                    Process.Start(new ProcessStartInfo(tempPath) { UseShellExecute = true });
+                    Application.Current.Shutdown();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                IsDownloading = false;
+                DownloadProgress = 0;
+                DownloadStatus = "";
+            }
+            catch (Exception ex)
+            {
+                IsDownloading = false;
+                HasError = true;
+                ErrorMessage = $"Download failed: {ex.Message}";
+            }
+        }
+
+        private void CancelDownload()
+        {
+            _cts.Cancel();
+        }
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/OATControl/DlgUpdateAvailable.xaml.cs
+++ b/OATControl/DlgUpdateAvailable.xaml.cs
@@ -6,6 +6,8 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Documents;
+using MdXaml;
 using OATCommunications.WPF;
 
 namespace OATControl
@@ -32,6 +34,11 @@ namespace OATControl
             this.WindowStartupLocation = WindowStartupLocation.CenterOwner;
             InitializeComponent();
             this.DataContext = this;
+
+            var themedStyle = new Style(typeof(FlowDocument), MarkdownStyle.Standard);
+            themedStyle.Setters.Add(new Setter(FlowDocument.ForegroundProperty, FindResource("AppForegroundBrush")));
+            themedStyle.Setters.Add(new Setter(FlowDocument.BackgroundProperty, Brushes.Transparent));
+            MarkdownViewer.MarkdownStyle = themedStyle;
 
             _skipCommand = new DelegateCommand(s => Close());
             _upgradeCommand = new DelegateCommand(s => StartDownload());

--- a/OATControl/DlgUpdateAvailable.xaml.cs
+++ b/OATControl/DlgUpdateAvailable.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Documents;
 using System.Windows.Media;
 using MdXaml;
 using OATCommunications.WPF;
+using OATControl.ViewModels;
 
 namespace OATControl
 {
@@ -23,6 +24,7 @@ namespace OATControl
         private bool _hasError;
         private string _errorMessage;
         private DelegateCommand _skipCommand;
+        private DelegateCommand _skipVersionCommand;
         private DelegateCommand _upgradeCommand;
         private DelegateCommand _cancelCommand;
 
@@ -39,19 +41,22 @@ namespace OATControl
             var themedStyle = new Style(typeof(FlowDocument), MarkdownStyle.Standard);
             themedStyle.Setters.Add(new Setter(FlowDocument.ForegroundProperty, FindResource("AppForegroundBrush")));
             themedStyle.Setters.Add(new Setter(FlowDocument.BackgroundProperty, Brushes.Transparent));
+            themedStyle.Setters.Add(new Setter(FlowDocument.FontSizeProperty, 13.0));
 
             themedStyle.Resources = new ResourceDictionary();
             var foreground = FindResource("AppForegroundBrush");
-            foreach (var key in new[] { "H1", "H2", "H3", "H4", "H5", "H6" })
-            {
-                var hs = new Style(typeof(Paragraph));
-                hs.Setters.Add(new Setter(Paragraph.ForegroundProperty, foreground));
-                themedStyle.Resources[key] = hs;
-            }
+
+            var paragraphStyle = new Style(typeof(Paragraph));
+            paragraphStyle.Triggers.Add(CreateHeadingTrigger("Heading1", foreground, 20, FontWeights.Bold));
+            paragraphStyle.Triggers.Add(CreateHeadingTrigger("Heading2", foreground, 18, FontWeights.SemiBold));
+            paragraphStyle.Triggers.Add(CreateHeadingTrigger("Heading3", foreground, 16, FontWeights.Normal));
+            paragraphStyle.Triggers.Add(CreateHeadingTrigger("Heading4", foreground, 14, FontWeights.Normal));
+            themedStyle.Resources[typeof(Paragraph)] = paragraphStyle;
 
             MarkdownViewer.MarkdownStyle = themedStyle;
 
             _skipCommand = new DelegateCommand(s => Close());
+            _skipVersionCommand = new DelegateCommand(s => { AppSettings.Instance.SkippedDesktopVersion = _result.LatestVersion; AppSettings.Instance.Save(); Close(); });
             _upgradeCommand = new DelegateCommand(s => StartDownload());
             _cancelCommand = new DelegateCommand(s => CancelDownload());
         }
@@ -90,6 +95,7 @@ namespace OATControl
         }
 
         public System.Windows.Input.ICommand SkipCommand => _skipCommand;
+        public System.Windows.Input.ICommand SkipVersionCommand => _skipVersionCommand;
         public System.Windows.Input.ICommand UpgradeCommand => _upgradeCommand;
         public System.Windows.Input.ICommand CancelCommand => _cancelCommand;
 
@@ -161,6 +167,15 @@ namespace OATControl
         private void CancelDownload()
         {
             _cts.Cancel();
+        }
+
+        private static Trigger CreateHeadingTrigger(string tag, object foreground, double fontSize, FontWeight fontWeight)
+        {
+            var trigger = new Trigger { Property = Paragraph.TagProperty, Value = tag };
+            trigger.Setters.Add(new Setter(Paragraph.ForegroundProperty, foreground));
+            trigger.Setters.Add(new Setter(Paragraph.FontSizeProperty, fontSize));
+            trigger.Setters.Add(new Setter(Paragraph.FontWeightProperty, fontWeight));
+            return trigger;
         }
 
         private void OnPropertyChanged(string propertyName)

--- a/OATControl/MainWindow.xaml
+++ b/OATControl/MainWindow.xaml
@@ -623,9 +623,9 @@
 			<Grid Grid.Row="4" Grid.Column="2" Width="125" Height="24" Margin="1,2" HorizontalAlignment="Right">
     <Button Content="Mount Settings" Padding="0" IsEnabled="{Binding MountConnected}" Style="{StaticResource MainButtonStyle}" Command="{Binding ShowSettingsCommand}"/>
     <Border Visibility="{Binding FirmwareUpdateAvailable, Converter={StaticResource CollapseIfFalse}}"
-            Width="16" Height="16" CornerRadius="8" Background="#E74C3C"
+            Width="16" Height="16" CornerRadius="8" Background="{DynamicResource AppForegroundAccentBrush}"
             HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,-6,-6,0">
-        <TextBlock Text="!" Foreground="White" FontWeight="Bold" FontSize="10"
+                    <TextBlock Text="!" Foreground="{DynamicResource AppNestedBackgroundBrush}" FontWeight="Bold" FontSize="10"
                    HorizontalAlignment="Center" VerticalAlignment="Center"/>
     </Border>
 </Grid>

--- a/OATControl/MainWindow.xaml
+++ b/OATControl/MainWindow.xaml
@@ -620,7 +620,15 @@
 				</Button.ContextMenu>
 			</Button>
 
-			<Button Grid.Row="4" Grid.Column="2" Content="Mount Settings" Height="24 " Margin="1,2" Width="125" HorizontalAlignment="Right" Padding="0" IsEnabled="{Binding MountConnected}" Style="{StaticResource MainButtonStyle}" Command="{Binding ShowSettingsCommand}"/>
+			<Grid Grid.Row="4" Grid.Column="2" Width="125" Height="24" Margin="1,2" HorizontalAlignment="Right">
+    <Button Content="Mount Settings" Padding="0" IsEnabled="{Binding MountConnected}" Style="{StaticResource MainButtonStyle}" Command="{Binding ShowSettingsCommand}"/>
+    <Border Visibility="{Binding FirmwareUpdateAvailable, Converter={StaticResource CollapseIfFalse}}"
+            Width="16" Height="16" CornerRadius="8" Background="#E74C3C"
+            HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,-6,-6,0">
+        <TextBlock Text="!" Foreground="White" FontWeight="Bold" FontSize="10"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Border>
+</Grid>
 
 			<Button Grid.Row="5" Grid.Column="2" Content="Log Files" Margin="0,6,66,2" Width="60" Height="24 " HorizontalAlignment="Right" Padding="0,0" Style="{StaticResource MainButtonStyle}" Command="{Binding ShowLogFolderCommand}" Visibility="{Binding IsLoggingEnabled, Converter={StaticResource CollapseIfFalse}}"/>
 			<Button Grid.Row="5" Grid.Column="2" Content="Checklist" Margin="0,6,1,2" Width="60" Height="24 " HorizontalAlignment="Right" Padding="0,0" Style="{StaticResource MainButtonStyle}" Command="{Binding ShowChecklistCommand}" />

--- a/OATControl/MainWindow.xaml.cs
+++ b/OATControl/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using OATControl.ViewModels;
 using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -34,11 +35,23 @@ namespace OATControl
 		protected override void OnContentRendered(EventArgs e)
 		{
 			base.OnContentRendered(e);
-			// Window is visible and ready
 			if (this.DataContext is MountVM vm)
 			{
 				vm.OnAppBooted();
 			}
+
+			_ = Task.Run(() => UpdateChecker.CheckForDesktopUpdateAsync())
+				.ContinueWith(t =>
+				{
+					if (!t.IsFaulted && !t.IsCanceled && t.Result?.UpdateAvailable == true)
+					{
+						Dispatcher.Invoke(() =>
+						{
+							var dlg = new DlgUpdateAvailable(t.Result);
+							dlg.ShowDialog();
+						});
+					}
+				});
 		}
 
 		protected override void OnClosing(CancelEventArgs e)

--- a/OATControl/OATControl Setup.iss
+++ b/OATControl/OATControl Setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "OATControl"
-#define MyAppVersion "1.2.0.0"
+#define MyAppVersion "1.2.1.0"
 #define MyAppPublisher "OpenAstroTech"
 #define MyAppURL "https://wiki.openastrotech.com/"
 #define MyAppExeName "OATControl.exe"
@@ -51,6 +51,8 @@ Source: ".\bin\Release\ASCOM.DriverAccess.dll"; DestDir: "{app}"; Flags: ignorev
 Source: ".\bin\Release\ASCOM.Exceptions.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: ".\bin\Release\ASCOM.Utilities.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: ".\bin\Release\OATControl.exe.config"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\bin\Release\MdXaml.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\bin\Release\MdXaml.Plugins.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: ".\bin\Release\PointsOfInterest.xml"; DestDir: "{app}"; Flags: ignoreversion
 Source: ".\bin\Release\System.Windows.Interactivity.dll"; DestDir: "{app}"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files

--- a/OATControl/OATControl.csproj
+++ b/OATControl/OATControl.csproj
@@ -143,6 +143,7 @@
     <Compile Include="DlgMessageBox.xaml.cs">
       <DependentUpon>DlgMessageBox.xaml</DependentUpon>
     </Compile>
+    <Compile Include="UpdateChecker.cs" />
     <Compile Include="DlgAxisCalibration.xaml.cs">
       <DependentUpon>DlgAxisCalibration.xaml</DependentUpon>
     </Compile>

--- a/OATControl/OATControl.csproj
+++ b/OATControl/OATControl.csproj
@@ -40,12 +40,22 @@
     <ApplicationIcon>oat.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ICSharpCode.AvalonEdit, Version=6.3.0.90, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
+      <HintPath>packages\AvalonEdit.6.3.0.90\lib\net462\ICSharpCode.AvalonEdit.dll</HintPath>
+    </Reference>
+    <Reference Include="MdXaml, Version=1.27.0.0, Culture=neutral, PublicKeyToken=9f8c7afb435b7edc, processorArchitecture=MSIL">
+      <HintPath>packages\MdXaml.1.27.0\lib\net462\MdXaml.dll</HintPath>
+    </Reference>
+    <Reference Include="MdXaml.Plugins, Version=1.27.0.0, Culture=neutral, PublicKeyToken=9f8c7afb435b7edc, processorArchitecture=MSIL">
+      <HintPath>packages\MdXaml.Plugins.1.27.0\lib\net462\MdXaml.Plugins.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />

--- a/OATControl/OATControl.csproj
+++ b/OATControl/OATControl.csproj
@@ -143,6 +143,9 @@
     <Compile Include="DlgMessageBox.xaml.cs">
       <DependentUpon>DlgMessageBox.xaml</DependentUpon>
     </Compile>
+    <Compile Include="DlgUpdateAvailable.xaml.cs">
+      <DependentUpon>DlgUpdateAvailable.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UpdateChecker.cs" />
     <Compile Include="DlgAxisCalibration.xaml.cs">
       <DependentUpon>DlgAxisCalibration.xaml</DependentUpon>
@@ -241,6 +244,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="DlgMessageBox.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="DlgUpdateAvailable.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/OATControl/Properties/AssemblyInfo.cs
+++ b/OATControl/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]

--- a/OATControl/Readme.txt
+++ b/OATControl/Readme.txt
@@ -1,6 +1,15 @@
 Revision History
 ----------------
 
+OATControl V1.2.1.0                                             24 May 2026
+- Automatic update checking for desktop app and firmware (GitHub releases).
+- Update dialog with themed markdown changelog and download with progress bar.
+- Firmware update badge on Mount Settings button and update link in Settings.
+- "Skip This Version" to suppress notifications for a specific release.
+- "Check For Updates" button in App Settings with inline result.
+- Update checks throttled to once per 24 hours. Manual check bypasses throttle.
+- Fault-tolerant — all network calls fire-and-forget with 5-second timeouts.
+
 OATControl V1.2.0.0                                             17 May 2026
 - Custom theme engine replaces MahApps.Metro dependency.
 - Built-in themes: Dark Astronomy, Daylight. Additional extgra Themes:

--- a/OATControl/SettingsDialog.xaml
+++ b/OATControl/SettingsDialog.xaml
@@ -187,9 +187,9 @@
 		<StackPanel Grid.Row="0" Grid.Column="1" Margin="0,12,0,2">
     <TextBlock Text="{Binding ScopeVersion}" Style="{StaticResource TextValueWide}"/>
     <TextBlock Visibility="{Binding FirmwareUpdateAvailable, Converter={StaticResource TrueBoolToVisible}}"
-               Foreground="#FF4A90D9" Cursor="Hand" HorizontalAlignment="Center"
+               Foreground="{DynamicResource AppForegroundAccentBrush}" Cursor="Hand" HorizontalAlignment="Center"
                MouseDown="OnFirmwareUpdateClick">
-        <Run Text="new "/><Run Text="{Binding LatestFirmwareVersion, Mode=OneWay}"/><Run Text=" available"/>
+        <Run Text="New "/><Run Text="{Binding LatestFirmwareVersion, Mode=OneWay}"/><Run Text=" available!"/>
     </TextBlock>
 </StackPanel>
 

--- a/OATControl/SettingsDialog.xaml
+++ b/OATControl/SettingsDialog.xaml
@@ -184,7 +184,14 @@
 
 
 		<TextBlock Grid.Row="0" Grid.Column="0" Text="Firmware:" HorizontalAlignment="Right" Style="{StaticResource TextLabel}" />
-		<TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding ScopeVersion}" Margin="0,12,0,2"  Style="{StaticResource TextValueWide}"/>
+		<StackPanel Grid.Row="0" Grid.Column="1" Margin="0,12,0,2">
+    <TextBlock Text="{Binding ScopeVersion}" Style="{StaticResource TextValueWide}"/>
+    <TextBlock Visibility="{Binding FirmwareUpdateAvailable, Converter={StaticResource TrueBoolToVisible}}"
+               Foreground="#FF4A90D9" Cursor="Hand" HorizontalAlignment="Center"
+               MouseDown="OnFirmwareUpdateClick">
+        <Run Text="new "/><Run Text="{Binding LatestFirmwareVersion, Mode=OneWay}"/><Run Text=" available"/>
+    </TextBlock>
+</StackPanel>
 
 		<TextBlock Grid.Row="1" Grid.Column="0" Text="Controller Board:" HorizontalAlignment="Right" Style="{StaticResource TextLabel}" />
 		<TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding ScopeBoard}"  Style="{StaticResource TextValueWide}" />

--- a/OATControl/SettingsDialog.xaml.cs
+++ b/OATControl/SettingsDialog.xaml.cs
@@ -14,7 +14,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
-using System.Windows.Dispatcher;
+using System.Windows.Threading;
 
 namespace OATControl
 {

--- a/OATControl/SettingsDialog.xaml.cs
+++ b/OATControl/SettingsDialog.xaml.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -13,7 +14,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
-using System.Windows.Threading;
+using System.Windows.Dispatcher;
 
 namespace OATControl
 {
@@ -58,6 +59,14 @@ namespace OATControl
 			dispatchTimer.Stop();
 			this.DataContext = null;
 			base.OnClosing(e);
+		}
+
+		private void OnFirmwareUpdateClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+		{
+			if (_mount?.LatestFirmwareReleaseUrl is string url)
+			{
+				Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+			}
 		}
 	}
 }

--- a/OATControl/UpdateChecker.cs
+++ b/OATControl/UpdateChecker.cs
@@ -61,8 +61,9 @@ namespace OATControl
 
                 return UpdateCheckResult.NoUpdate;
             }
-            catch
+            catch (Exception ex)
             {
+                System.Diagnostics.Debug.WriteLine($"UpdateChecker desktop check failed: {ex.Message}");
                 return UpdateCheckResult.NoUpdate;
             }
         }
@@ -97,8 +98,9 @@ namespace OATControl
 
                 return UpdateCheckResult.NoUpdate;
             }
-            catch
+            catch (Exception ex)
             {
+                System.Diagnostics.Debug.WriteLine($"UpdateChecker firmware check failed: {ex.Message}");
                 return UpdateCheckResult.NoUpdate;
             }
         }

--- a/OATControl/UpdateChecker.cs
+++ b/OATControl/UpdateChecker.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using OATControl.ViewModels;
 
 namespace OATControl
 {
@@ -23,6 +24,10 @@ namespace OATControl
         private const string DesktopRepoUrl = "https://api.github.com/repos/OpenAstroTech/OpenAstroTracker-Desktop/releases/latest";
         private const string FirmwareRepoUrl = "https://api.github.com/repos/OpenAstroTech/OpenAstroTracker-Firmware/releases/latest";
 
+        private static DateTime _lastDesktopCheck = DateTime.MinValue;
+        private static DateTime _lastFirmwareCheck = DateTime.MinValue;
+        private static readonly TimeSpan CheckInterval = TimeSpan.FromHours(24);
+
         private static readonly HttpClient _httpClient = new HttpClient(new HttpClientHandler())
         {
             Timeout = TimeSpan.FromSeconds(5)
@@ -35,6 +40,9 @@ namespace OATControl
 
         public static async Task<UpdateCheckResult> CheckForDesktopUpdateAsync()
         {
+            if (DateTime.UtcNow - _lastDesktopCheck < CheckInterval)
+                return UpdateCheckResult.NoUpdate;
+
             try
             {
                 var currentVersion = Assembly.GetExecutingAssembly().GetName().Version;
@@ -42,16 +50,21 @@ namespace OATControl
                 if (release == null)
                     return UpdateCheckResult.NoUpdate;
 
+                var tagName = UppercaseVersion(release["tag_name"]?.ToString());
                 var tagVersion = ParseVersionTag(release["tag_name"]?.ToString());
                 if (tagVersion == null || currentVersion == null)
                     return UpdateCheckResult.NoUpdate;
 
                 if (tagVersion > currentVersion)
                 {
+                    if (AppSettings.Instance.SkippedDesktopVersion == tagName)
+                        return UpdateCheckResult.NoUpdate;
+
+                    _lastDesktopCheck = DateTime.UtcNow;
                     return new UpdateCheckResult
                     {
                         UpdateAvailable = true,
-                        LatestVersion = release["tag_name"].ToString(),
+                        LatestVersion = tagName,
                         CurrentVersion = $"V{currentVersion}",
                         Changelog = release["body"]?.ToString() ?? "",
                         DownloadUrl = release["assets"]?[0]?["browser_download_url"]?.ToString(),
@@ -68,8 +81,25 @@ namespace OATControl
             }
         }
 
+        public static void ResetDesktopCheckTimer()
+        {
+            _lastDesktopCheck = DateTime.MinValue;
+        }
+
+        static string UppercaseVersion(string tag)
+        {
+            if (!string.IsNullOrEmpty(tag) && tag.StartsWith("v"))
+            {
+                tag= 'V' + tag.Substring(1);
+            }
+            return tag;
+        }
+
         public static async Task<UpdateCheckResult> CheckForFirmwareUpdateAsync(string currentFirmwareVersion)
         {
+            if (DateTime.UtcNow - _lastFirmwareCheck < CheckInterval)
+                return UpdateCheckResult.NoUpdate;
+
             try
             {
                 var currentVersion = ParseVersionTag(currentFirmwareVersion);
@@ -80,17 +110,20 @@ namespace OATControl
                 if (release == null)
                     return UpdateCheckResult.NoUpdate;
 
-                var tagVersion = ParseVersionTag(release["tag_name"]?.ToString());
+                var tagName = UppercaseVersion(release["tag_name"].ToString());
+                var tagVersion = ParseVersionTag(tagName);
                 if (tagVersion == null)
                     return UpdateCheckResult.NoUpdate;
 
+                
                 if (tagVersion > currentVersion)
                 {
+                    _lastFirmwareCheck = DateTime.UtcNow;
                     return new UpdateCheckResult
                     {
                         UpdateAvailable = true,
-                        LatestVersion = release["tag_name"].ToString(),
-                        CurrentVersion = currentFirmwareVersion,
+                        LatestVersion = tagName,
+                        CurrentVersion = UppercaseVersion(currentFirmwareVersion),
                         Changelog = release["body"]?.ToString() ?? "",
                         ReleasePageUrl = release["html_url"]?.ToString()
                     };

--- a/OATControl/UpdateChecker.cs
+++ b/OATControl/UpdateChecker.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace OATControl
+{
+    public class UpdateCheckResult
+    {
+        public bool UpdateAvailable { get; set; }
+        public string LatestVersion { get; set; }
+        public string CurrentVersion { get; set; }
+        public string Changelog { get; set; }
+        public string DownloadUrl { get; set; }
+        public string ReleasePageUrl { get; set; }
+
+        public static UpdateCheckResult NoUpdate => new UpdateCheckResult();
+    }
+
+    public static class UpdateChecker
+    {
+        private const string DesktopRepoUrl = "https://api.github.com/repos/OpenAstroTech/OpenAstroTracker-Desktop/releases/latest";
+        private const string FirmwareRepoUrl = "https://api.github.com/repos/OpenAstroTech/OpenAstroTracker-Firmware/releases/latest";
+
+        private static readonly HttpClient _httpClient = new HttpClient(new HttpClientHandler())
+        {
+            Timeout = TimeSpan.FromSeconds(5)
+        };
+
+        static UpdateChecker()
+        {
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "OATControl");
+        }
+
+        public static async Task<UpdateCheckResult> CheckForDesktopUpdateAsync()
+        {
+            try
+            {
+                var currentVersion = Assembly.GetExecutingAssembly().GetName().Version;
+                var release = await FetchLatestReleaseAsync(DesktopRepoUrl);
+                if (release == null)
+                    return UpdateCheckResult.NoUpdate;
+
+                var tagVersion = ParseVersionTag(release["tag_name"]?.ToString());
+                if (tagVersion == null || currentVersion == null)
+                    return UpdateCheckResult.NoUpdate;
+
+                if (tagVersion > currentVersion)
+                {
+                    return new UpdateCheckResult
+                    {
+                        UpdateAvailable = true,
+                        LatestVersion = release["tag_name"].ToString(),
+                        CurrentVersion = $"V{currentVersion}",
+                        Changelog = release["body"]?.ToString() ?? "",
+                        DownloadUrl = release["assets"]?[0]?["browser_download_url"]?.ToString(),
+                        ReleasePageUrl = release["html_url"]?.ToString()
+                    };
+                }
+
+                return UpdateCheckResult.NoUpdate;
+            }
+            catch
+            {
+                return UpdateCheckResult.NoUpdate;
+            }
+        }
+
+        public static async Task<UpdateCheckResult> CheckForFirmwareUpdateAsync(string currentFirmwareVersion)
+        {
+            try
+            {
+                var currentVersion = ParseVersionTag(currentFirmwareVersion);
+                if (currentVersion == null)
+                    return UpdateCheckResult.NoUpdate;
+
+                var release = await FetchLatestReleaseAsync(FirmwareRepoUrl);
+                if (release == null)
+                    return UpdateCheckResult.NoUpdate;
+
+                var tagVersion = ParseVersionTag(release["tag_name"]?.ToString());
+                if (tagVersion == null)
+                    return UpdateCheckResult.NoUpdate;
+
+                if (tagVersion > currentVersion)
+                {
+                    return new UpdateCheckResult
+                    {
+                        UpdateAvailable = true,
+                        LatestVersion = release["tag_name"].ToString(),
+                        CurrentVersion = currentFirmwareVersion,
+                        Changelog = release["body"]?.ToString() ?? "",
+                        ReleasePageUrl = release["html_url"]?.ToString()
+                    };
+                }
+
+                return UpdateCheckResult.NoUpdate;
+            }
+            catch
+            {
+                return UpdateCheckResult.NoUpdate;
+            }
+        }
+
+        private static async Task<JObject> FetchLatestReleaseAsync(string url)
+        {
+            var response = await _httpClient.GetAsync(url);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync();
+            return JObject.Parse(json);
+        }
+
+        private static Version ParseVersionTag(string tag)
+        {
+            if (string.IsNullOrEmpty(tag))
+                return null;
+
+            // Strip leading 'V' or 'v'
+            var versionStr = tag.TrimStart('V', 'v');
+
+            Version result;
+            if (Version.TryParse(versionStr, out result))
+                return result;
+
+            return null;
+        }
+    }
+}

--- a/OATControl/ViewModels/AppSettings.cs
+++ b/OATControl/ViewModels/AppSettings.cs
@@ -566,5 +566,12 @@ namespace OATControl.ViewModels
             get { return this["ThemeName"]; }
             set { this["ThemeName"] = value; }
         }
+
+        [DefaultValueAttribute("")]
+        public string SkippedDesktopVersion
+        {
+            get { return this["SkippedDesktopVersion"]; }
+            set { this["SkippedDesktopVersion"] = value; }
+        }
     }
 }

--- a/OATControl/ViewModels/MountVM.cs
+++ b/OATControl/ViewModels/MountVM.cs
@@ -18,6 +18,7 @@ using OATCommunications.Utilities;
 using CommandResponse = OATCommunications.CommunicationHandlers.CommandResponse;
 using System.Xml.Linq;
 using Newtonsoft.Json.Linq;
+using OATControl.Utilities;
 
 namespace OATControl.ViewModels
 {
@@ -197,6 +198,9 @@ namespace OATControl.ViewModels
         private PointsOfInterest _pointsOfInterest;
         PointOfInterest _selectedPointOfInterest;
         private long _firmwareVersion = 0;
+        private bool _firmwareUpdateAvailable;
+        private string _latestFirmwareVersion;
+        private string _latestFirmwareReleaseUrl;
         private float _slewYSpeed;
         private float _slewXSpeed;
         private int _slewRate = 5;
@@ -2855,6 +2859,17 @@ namespace OATControl.ViewModels
 
             _oatMount.SetFirmwareVersion(FirmwareVersion);
 
+            _ = Task.Run(() => UpdateChecker.CheckForFirmwareUpdateAsync(ScopeVersion))
+                .ContinueWith(t =>
+                {
+                    if (!t.IsFaulted && !t.IsCanceled && t.Result?.UpdateAvailable == true)
+                    {
+                        FirmwareUpdateAvailable = true;
+                        LatestFirmwareVersion = t.Result.LatestVersion;
+                        LatestFirmwareReleaseUrl = t.Result.ReleasePageUrl;
+                    }
+                }, TaskScheduler.FromCurrentSynchronizationContext());
+
             var doneEvent2 = new AsyncAutoResetEvent();
             string hwData = string.Empty;
 
@@ -4739,6 +4754,24 @@ namespace OATControl.ViewModels
         {
             get { return _firmwareVersion; }
             set { SetPropertyValue(ref _firmwareVersion, value); }
+        }
+
+        public bool FirmwareUpdateAvailable
+        {
+            get => _firmwareUpdateAvailable;
+            set => SetPropertyValue(ref _firmwareUpdateAvailable, value);
+        }
+
+        public string LatestFirmwareVersion
+        {
+            get => _latestFirmwareVersion;
+            set => SetPropertyValue(ref _latestFirmwareVersion, value);
+        }
+
+        public string LatestFirmwareReleaseUrl
+        {
+            get => _latestFirmwareReleaseUrl;
+            set => SetPropertyValue(ref _latestFirmwareReleaseUrl, value);
         }
 
         public PointOfInterest SelectedPointOfInterest

--- a/OATControl/ViewModels/MountVM.cs
+++ b/OATControl/ViewModels/MountVM.cs
@@ -18,7 +18,7 @@ using OATCommunications.Utilities;
 using CommandResponse = OATCommunications.CommunicationHandlers.CommandResponse;
 using System.Xml.Linq;
 using Newtonsoft.Json.Linq;
-using OATControl.Utilities;
+
 
 namespace OATControl.ViewModels
 {

--- a/OATControl/packages.config
+++ b/OATControl/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AvalonEdit" version="6.3.0.90" targetFramework="net472" />
+  <package id="MdXaml" version="1.27.0" targetFramework="net472" />
+  <package id="MdXaml.Plugins" version="1.27.0" targetFramework="net472" />
   <package id="Microsoft.Web.WebView2" version="1.0.2792.45" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
 </packages>

--- a/docs/superpowers/plans/2026-05-24-update-checker.md
+++ b/docs/superpowers/plans/2026-05-24-update-checker.md
@@ -1,0 +1,685 @@
+# GitHub Release Update Checker — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add automatic GitHub release checking for the OATControl desktop app (at startup) and mount firmware (on connect), with a modal update dialog for the desktop and inline notification for firmware.
+
+**Architecture:** Single `UpdateChecker` static class handles both GitHub API queries. A new `DlgUpdateAvailable` dialog handles the desktop update flow (changelog display, download with progress, launch installer). MountVM gets three new bindable properties for the firmware update badge. All network calls are fire-and-forget with 5-second timeouts and silent failure.
+
+**Tech Stack:** .NET Framework 4.7.2, WPF, Newtonsoft.Json (already in project), HttpClient
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `OATControl/UpdateChecker.cs` | GitHub API queries, version parsing, comparison |
+| Create | `OATControl/DlgUpdateAvailable.xaml` | Desktop update dialog layout |
+| Create | `OATControl/DlgUpdateAvailable.xaml.cs` | Dialog code-behind (changelog, download, progress) |
+| Modify | `OATControl/OATControl.csproj` | Add new files to project |
+| Modify | `OATControl/ViewModels/MountVM.cs` | Add 3 properties + firmware check call |
+| Modify | `OATControl/MainWindow.xaml` | Add badge on Mount Settings button |
+| Modify | `OATControl/MainWindow.xaml.cs` | Add desktop update check on startup |
+| Modify | `OATControl/SettingsDialog.xaml` | Add firmware update link below version |
+
+---
+
+### Task 1: Create UpdateChecker and UpdateCheckResult
+
+**Files:**
+- Create: `OATControl/UpdateChecker.cs`
+
+- [ ] **Step 1: Create the UpdateChecker.cs file**
+
+```csharp
+using System;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace OATControl
+{
+    public class UpdateCheckResult
+    {
+        public bool UpdateAvailable { get; set; }
+        public string LatestVersion { get; set; }
+        public string CurrentVersion { get; set; }
+        public string Changelog { get; set; }
+        public string DownloadUrl { get; set; }
+        public string ReleasePageUrl { get; set; }
+
+        public static UpdateCheckResult NoUpdate => new UpdateCheckResult();
+    }
+
+    public static class UpdateChecker
+    {
+        private const string DesktopRepoUrl = "https://api.github.com/repos/OpenAstroTech/OpenAstroTracker-Desktop/releases/latest";
+        private const string FirmwareRepoUrl = "https://api.github.com/repos/OpenAstroTech/OpenAstroTracker-Firmware/releases/latest";
+
+        private static readonly HttpClient _httpClient = new HttpClient(new HttpClientHandler())
+        {
+            Timeout = TimeSpan.FromSeconds(5)
+        };
+
+        static UpdateChecker()
+        {
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "OATControl");
+        }
+
+        public static async Task<UpdateCheckResult> CheckForDesktopUpdateAsync()
+        {
+            try
+            {
+                var currentVersion = Assembly.GetExecutingAssembly().GetName().Version;
+                var release = await FetchLatestReleaseAsync(DesktopRepoUrl);
+                if (release == null)
+                    return UpdateCheckResult.NoUpdate;
+
+                var tagVersion = ParseVersionTag(release["tag_name"]?.ToString());
+                if (tagVersion == null || currentVersion == null)
+                    return UpdateCheckResult.NoUpdate;
+
+                if (tagVersion > currentVersion)
+                {
+                    return new UpdateCheckResult
+                    {
+                        UpdateAvailable = true,
+                        LatestVersion = release["tag_name"].ToString(),
+                        CurrentVersion = $"V{currentVersion}",
+                        Changelog = release["body"]?.ToString() ?? "",
+                        DownloadUrl = release["assets"]?[0]?["browser_download_url"]?.ToString(),
+                        ReleasePageUrl = release["html_url"]?.ToString()
+                    };
+                }
+
+                return UpdateCheckResult.NoUpdate;
+            }
+            catch
+            {
+                return UpdateCheckResult.NoUpdate;
+            }
+        }
+
+        public static async Task<UpdateCheckResult> CheckForFirmwareUpdateAsync(string currentFirmwareVersion)
+        {
+            try
+            {
+                var currentVersion = ParseVersionTag(currentFirmwareVersion);
+                if (currentVersion == null)
+                    return UpdateCheckResult.NoUpdate;
+
+                var release = await FetchLatestReleaseAsync(FirmwareRepoUrl);
+                if (release == null)
+                    return UpdateCheckResult.NoUpdate;
+
+                var tagVersion = ParseVersionTag(release["tag_name"]?.ToString());
+                if (tagVersion == null)
+                    return UpdateCheckResult.NoUpdate;
+
+                if (tagVersion > currentVersion)
+                {
+                    return new UpdateCheckResult
+                    {
+                        UpdateAvailable = true,
+                        LatestVersion = release["tag_name"].ToString(),
+                        CurrentVersion = currentFirmwareVersion,
+                        Changelog = release["body"]?.ToString() ?? "",
+                        ReleasePageUrl = release["html_url"]?.ToString()
+                    };
+                }
+
+                return UpdateCheckResult.NoUpdate;
+            }
+            catch
+            {
+                return UpdateCheckResult.NoUpdate;
+            }
+        }
+
+        private static async Task<JObject> FetchLatestReleaseAsync(string url)
+        {
+            var response = await _httpClient.GetAsync(url);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync();
+            return JObject.Parse(json);
+        }
+
+        private static Version ParseVersionTag(string tag)
+        {
+            if (string.IsNullOrEmpty(tag))
+                return null;
+
+            // Strip leading 'V' or 'v'
+            var versionStr = tag.TrimStart('V', 'v');
+
+            Version result;
+            if (Version.TryParse(versionStr, out result))
+                return result;
+
+            // Try padding to at least 2 parts (e.g., "1.13" → "1.13.0")
+            var parts = versionStr.Split('.');
+            if (parts.Length < 2)
+                return null;
+
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the file to OATControl.csproj**
+
+In `OATControl/OATControl.csproj`, add after the existing `<Compile Include="DlgMessageBox.xaml.cs">` block (around line 145):
+
+```xml
+    <Compile Include="UpdateChecker.cs" />
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add OATControl/UpdateChecker.cs OATControl/OATControl.csproj
+git commit -m "feat: add UpdateChecker with GitHub release query logic"
+```
+
+---
+
+### Task 2: Create DlgUpdateAvailable dialog
+
+**Files:**
+- Create: `OATControl/DlgUpdateAvailable.xaml`
+- Create: `OATControl/DlgUpdateAvailable.xaml.cs`
+- Modify: `OATControl/OATControl.csproj`
+
+- [ ] **Step 1: Create DlgUpdateAvailable.xaml**
+
+This dialog follows the existing ThemedWindow pattern (see `DlgMessageBox.xaml`). Two visual states: info (changelog + buttons) and downloading (progress bar + cancel).
+
+```xml
+<controls:ThemedWindow x:Class="OATControl.DlgUpdateAvailable"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:controls="clr-namespace:OATControl.Controls"
+        mc:Ignorable="d"
+        Title="Update Available" Height="420" Width="500"
+        ResizeMode="NoResize"
+        controls:ThemedWindow.TitleBarButtons="Close">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Version info -->
+        <TextBlock Grid.Row="0" Text="{Binding VersionInfo}" FontWeight="Bold" FontSize="14"
+                   Foreground="{DynamicResource AppForegroundBrush}" Margin="0,0,0,12" TextWrapping="Wrap"/>
+
+        <!-- Info state: changelog -->
+        <TextBox Grid.Row="1" Text="{Binding Changelog}" IsReadOnly="True" TextWrapping="Wrap"
+                 VerticalScrollBarVisibility="Auto" AcceptsReturn="True"
+                 Padding="8" Margin="0,0,0,12"
+                 Visibility="{Binding IsDownloading, Converter={StaticResource InvertBoolToCollapsed}}"/>
+
+        <!-- Download state: progress -->
+        <StackPanel Grid.Row="1" Visibility="{Binding IsDownloading, Converter={StaticResource BoolToVisible}}"
+                    VerticalAlignment="Center" Margin="0,0,0,12">
+            <TextBlock Text="Downloading update..." Margin="0,0,0,8"
+                       Foreground="{DynamicResource AppForegroundBrush}"/>
+            <ProgressBar Value="{Binding DownloadProgress}" Height="20" Minimum="0" Maximum="100"/>
+            <TextBlock Text="{Binding DownloadStatus}" Margin="0,4,0,0" HorizontalAlignment="Center"
+                       Foreground="{DynamicResource AppForegroundBrush}"/>
+        </StackPanel>
+
+        <!-- Error message -->
+        <TextBlock Grid.Row="1" Text="{Binding ErrorMessage}" Foreground="Red" TextWrapping="Wrap"
+                   Visibility="{Binding HasError, Converter={StaticResource BoolToVisible}}"
+                   VerticalAlignment="Center" HorizontalAlignment="Center"/>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Skip" Width="80" Height="28" Margin="0,0,8,0"
+                    Style="{StaticResource MainButtonStyle}"
+                    Command="{Binding SkipCommand}"
+                    Visibility="{Binding IsDownloading, Converter={StaticResource InvertBoolToCollapsed}}"/>
+            <Button Content="Cancel" Width="80" Height="28" Margin="0,0,8,0"
+                    Style="{StaticResource MainButtonStyle}"
+                    Command="{Binding CancelCommand}"
+                    Visibility="{Binding IsDownloading, Converter={StaticResource BoolToVisible}}"/>
+            <Button Content="Upgrade" Width="80" Height="28"
+                    Style="{StaticResource MainButtonStyle}"
+                    Command="{Binding UpgradeCommand}"
+                    Visibility="{Binding IsDownloading, Converter={StaticResource InvertBoolToCollapsed}}"/>
+        </StackPanel>
+    </Grid>
+
+    <controls:ThemedWindow.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVisible" Collapse="False"/>
+        <converters:BoolToVisibilityConverter x:Key="InvertBoolToCollapsed" Collapse="True" IsReversed="True"/>
+    </controls:ThemedWindow.Resources>
+</controls:ThemedWindow>
+```
+
+- [ ] **Step 2: Create DlgUpdateAvailable.xaml.cs**
+
+Follows the pattern from `DlgMessageBox.xaml.cs`: inherits `Controls.ThemedWindow`, sets `Owner` to main window, uses `INotifyPropertyChanged` and `DelegateCommand`.
+
+```csharp
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using OATCommunications.WPF;
+
+namespace OATControl
+{
+    public partial class DlgUpdateAvailable : Controls.ThemedWindow, INotifyPropertyChanged
+    {
+        private readonly UpdateCheckResult _result;
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private bool _isDownloading;
+        private int _downloadProgress;
+        private string _downloadStatus;
+        private bool _hasError;
+        private string _errorMessage;
+        private DelegateCommand _skipCommand;
+        private DelegateCommand _upgradeCommand;
+        private DelegateCommand _cancelCommand;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public DlgUpdateAvailable(UpdateCheckResult result)
+        {
+            _result = result;
+            this.Owner = Application.Current.MainWindow;
+            this.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            InitializeComponent();
+            this.DataContext = this;
+
+            _skipCommand = new DelegateCommand(s => Close());
+            _upgradeCommand = new DelegateCommand(s => StartDownload());
+            _cancelCommand = new DelegateCommand(s => CancelDownload());
+        }
+
+        public string VersionInfo => $"OATControl {_result.LatestVersion} is now available (you have {_result.CurrentVersion})";
+        public string Changelog => _result.Changelog;
+
+        public bool IsDownloading
+        {
+            get => _isDownloading;
+            set { _isDownloading = value; OnPropertyChanged(nameof(IsDownloading)); }
+        }
+
+        public int DownloadProgress
+        {
+            get => _downloadProgress;
+            set { _downloadProgress = value; OnPropertyChanged(nameof(DownloadProgress)); }
+        }
+
+        public string DownloadStatus
+        {
+            get => _downloadStatus;
+            set { _downloadStatus = value; OnPropertyChanged(nameof(DownloadStatus)); }
+        }
+
+        public bool HasError
+        {
+            get => _hasError;
+            set { _hasError = value; OnPropertyChanged(nameof(HasError)); }
+        }
+
+        public string ErrorMessage
+        {
+            get => _errorMessage;
+            set { _errorMessage = value; OnPropertyChanged(nameof(ErrorMessage)); }
+        }
+
+        public System.Windows.Input.ICommand SkipCommand => _skipCommand;
+        public System.Windows.Input.ICommand UpgradeCommand => _upgradeCommand;
+        public System.Windows.Input.ICommand CancelCommand => _cancelCommand;
+
+        private async void StartDownload()
+        {
+            if (string.IsNullOrEmpty(_result.DownloadUrl))
+            {
+                HasError = true;
+                ErrorMessage = "No download URL available.";
+                return;
+            }
+
+            IsDownloading = true;
+            HasError = false;
+
+            try
+            {
+                var tempPath = Path.Combine(Path.GetTempPath(), "OATControlSetup.exe");
+
+                using (var client = new HttpClient { Timeout = TimeSpan.FromMinutes(5) })
+                using (var response = await client.GetAsync(_result.DownloadUrl, HttpCompletionOption.ResponseHeadersRead, _cts.Token))
+                {
+                    response.EnsureSuccessStatusCode();
+                    var totalBytes = response.Content.Headers.ContentLength ?? -1L;
+
+                    using (var stream = await response.Content.ReadAsStreamAsync())
+                    using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                    {
+                        var buffer = new byte[8192];
+                        long bytesRead = 0;
+                        int read;
+
+                        while ((read = await stream.ReadAsync(buffer, 0, buffer.Length, _cts.Token)) > 0)
+                        {
+                            await fileStream.WriteAsync(buffer, 0, read, _cts.Token);
+                            bytesRead += read;
+
+                            if (totalBytes > 0)
+                            {
+                                var progress = (int)(bytesRead * 100 / totalBytes);
+                                DownloadProgress = progress;
+                                DownloadStatus = $"{bytesRead / 1024} KB / {totalBytes / 1024} KB ({progress}%)";
+                            }
+                            else
+                            {
+                                DownloadStatus = $"{bytesRead / 1024} KB downloaded";
+                            }
+                        }
+                    }
+
+                    Process.Start(new ProcessStartInfo(tempPath) { UseShellExecute = true });
+                    Application.Current.Shutdown();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                IsDownloading = false;
+                DownloadProgress = 0;
+                DownloadStatus = "";
+            }
+            catch (Exception ex)
+            {
+                IsDownloading = false;
+                HasError = true;
+                ErrorMessage = $"Download failed: {ex.Message}";
+            }
+        }
+
+        private void CancelDownload()
+        {
+            _cts.Cancel();
+        }
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add files to OATControl.csproj**
+
+Add near the other dialog entries (around lines 143-146 and 242):
+
+```xml
+    <Compile Include="DlgUpdateAvailable.xaml.cs">
+      <DependentUpon>DlgUpdateAvailable.xaml</DependentUpon>
+    </Compile>
+```
+
+And in the `<Page>` items (around line 242):
+
+```xml
+    <Page Include="DlgUpdateAvailable.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add OATControl/DlgUpdateAvailable.xaml OATControl/DlgUpdateAvailable.xaml.cs OATControl/OATControl.csproj
+git commit -m "feat: add DlgUpdateAvailable dialog with download and progress"
+```
+
+---
+
+### Task 3: Wire up desktop update check at startup
+
+**Files:**
+- Modify: `OATControl/MainWindow.xaml.cs` (lines 1-6, 34-42)
+- Modify: `OATControl/ViewModels/MountVM.cs` (line 261-267)
+
+- [ ] **Step 1: Add desktop update check in MainWindow.xaml.cs**
+
+Add `using` statements at the top (after existing usings, around line 5):
+
+```csharp
+using System.Threading.Tasks;
+```
+
+Modify the `OnContentRendered` method (line 34-42) to add the update check after `vm.OnAppBooted()`:
+
+```csharp
+protected override void OnContentRendered(EventArgs e)
+{
+    base.OnContentRendered(e);
+    if (this.DataContext is MountVM vm)
+    {
+        vm.OnAppBooted();
+    }
+
+    _ = Task.Run(() => UpdateChecker.CheckForDesktopUpdateAsync())
+        .ContinueWith(t =>
+        {
+            if (!t.IsFaulted && !t.IsCanceled && t.Result?.UpdateAvailable == true)
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    var dlg = new DlgUpdateAvailable(t.Result);
+                    dlg.ShowDialog();
+                });
+            }
+        });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add OATControl/MainWindow.xaml.cs
+git commit -m "feat: check for desktop updates on app startup"
+```
+
+---
+
+### Task 4: Add firmware update properties to MountVM
+
+**Files:**
+- Modify: `OATControl/ViewModels/MountVM.cs`
+
+- [ ] **Step 1: Add backing fields**
+
+Near the existing `_firmwareVersion` field at line 199, add:
+
+```csharp
+        private bool _firmwareUpdateAvailable;
+        private string _latestFirmwareVersion;
+        private string _latestFirmwareReleaseUrl;
+```
+
+- [ ] **Step 2: Add properties**
+
+Near the existing `FirmwareVersion` property (around line 4738), add:
+
+```csharp
+        public bool FirmwareUpdateAvailable
+        {
+            get => _firmwareUpdateAvailable;
+            set => SetPropertyValue(ref _firmwareUpdateAvailable, value);
+        }
+
+        public string LatestFirmwareVersion
+        {
+            get => _latestFirmwareVersion;
+            set => SetPropertyValue(ref _latestFirmwareVersion, value);
+        }
+
+        public string LatestFirmwareReleaseUrl
+        {
+            get => _latestFirmwareReleaseUrl;
+            set => SetPropertyValue(ref _latestFirmwareReleaseUrl, value);
+        }
+```
+
+- [ ] **Step 3: Add firmware update check call after connection**
+
+In `MountVM.cs`, after `_oatMount.SetFirmwareVersion(FirmwareVersion)` (line 2856), add the firmware update check:
+
+```csharp
+            _ = Task.Run(() => UpdateChecker.CheckForFirmwareUpdateAsync(ScopeVersion))
+                .ContinueWith(t =>
+                {
+                    if (!t.IsFaulted && !t.IsCanceled && t.Result?.UpdateAvailable == true)
+                    {
+                        FirmwareUpdateAvailable = true;
+                        LatestFirmwareVersion = t.Result.LatestVersion;
+                        LatestFirmwareReleaseUrl = t.Result.ReleasePageUrl;
+                    }
+                }, TaskScheduler.FromCurrentSynchronizationContext());
+```
+
+This must be placed inside the `try` block of `ConnectToOat`, after the firmware version has been successfully parsed, near line 2856.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add OATControl/ViewModels/MountVM.cs
+git commit -m "feat: add firmware update check on mount connection"
+```
+
+---
+
+### Task 5: Add firmware update badge on Mount Settings button
+
+**Files:**
+- Modify: `OATControl/MainWindow.xaml` (line 623)
+
+- [ ] **Step 1: Replace the Mount Settings button with a Grid containing the button and badge**
+
+Replace line 623:
+
+```xml
+<Button Grid.Row="4" Grid.Column="2" Content="Mount Settings" Height="24 " Margin="1,2" Width="125" HorizontalAlignment="Right" Padding="0" IsEnabled="{Binding MountConnected}" Style="{StaticResource MainButtonStyle}" Command="{Binding ShowSettingsCommand}"/>
+```
+
+With:
+
+```xml
+<Grid Grid.Row="4" Grid.Column="2" Width="125" Height="24" Margin="1,2" HorizontalAlignment="Right">
+    <Button Content="Mount Settings" Padding="0" IsEnabled="{Binding MountConnected}" Style="{StaticResource MainButtonStyle}" Command="{Binding ShowSettingsCommand}"/>
+    <Border Visibility="{Binding FirmwareUpdateAvailable, Converter={StaticResource CollapseIfFalse}}"
+            Width="16" Height="16" CornerRadius="8" Background="#E74C3C"
+            HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,-6,-6,0">
+        <TextBlock Text="!" Foreground="White" FontWeight="Bold" FontSize="10"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Border>
+</Grid>
+```
+
+This reuses the existing `CollapseIfFalse` converter already defined at line 18 of MainWindow.xaml.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add OATControl/MainWindow.xaml
+git commit -m "feat: add firmware update badge on Mount Settings button"
+```
+
+---
+
+### Task 6: Add firmware update link in SettingsDialog
+
+**Files:**
+- Modify: `OATControl/SettingsDialog.xaml` (around line 189)
+
+- [ ] **Step 1: Add firmware update hyperlink below the version display**
+
+Replace the firmware version TextBlock (line 189):
+
+```xml
+<TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding ScopeVersion}" Margin="0,12,0,2"  Style="{StaticResource TextValueWide}"/>
+```
+
+With:
+
+```xml
+<StackPanel Grid.Row="0" Grid.Column="1" Margin="0,12,0,2">
+    <TextBlock Text="{Binding ScopeVersion}" Style="{StaticResource TextValueWide}"/>
+    <TextBlock Visibility="{Binding FirmwareUpdateAvailable, Converter={StaticResource TrueBoolToVisible}}"
+               Foreground="#FF4A90D9" Cursor="Hand" HorizontalAlignment="Center"
+               MouseDown="OnFirmwareUpdateClick">
+        <Run Text="new "/><Run Text="{Binding LatestFirmwareVersion, Mode=OneWay}"/><Run Text=" available"/>
+    </TextBlock>
+</StackPanel>
+```
+
+Note: `TrueBoolToVisible` is already defined in SettingsDialog.xaml resources at line 13.
+
+- [ ] **Step 2: Add click handler in SettingsDialog.xaml.cs**
+
+Add `using System.Diagnostics;` at the top if not already present, and add this method to the `SettingsDialog` class (inside the class body, around line 60):
+
+```csharp
+private void OnFirmwareUpdateClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+{
+    if (_mount?.LatestFirmwareReleaseUrl is string url)
+    {
+        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+    }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add OATControl/SettingsDialog.xaml OATControl/SettingsDialog.xaml.cs
+git commit -m "feat: add firmware update link in Settings dialog"
+```
+
+---
+
+### Task 7: Build and verify
+
+- [ ] **Step 1: Build the solution in Visual Studio**
+
+Open `OATControl/OATControl.sln` in Visual Studio and build. Fix any compilation errors.
+
+Expected: clean build with no errors.
+
+- [ ] **Step 2: Manual test — desktop update check**
+
+Run OATControl. Since the current version matches the latest release (V1.2.0.0), no dialog should appear. To test the dialog, temporarily change the version in `AssemblyInfo.cs` to `1.0.0.0`, rebuild, and verify the dialog appears.
+
+- [ ] **Step 3: Manual test — firmware update check**
+
+Connect to a mount (real or simulated). Verify that if the firmware version is older than the latest GitHub release, the badge appears on "Mount Settings" and the inline link shows in the Settings dialog. Click the link to verify it opens the browser.
+
+- [ ] **Step 4: Manual test — offline resilience**
+
+Disconnect from the internet. Start OATControl and connect to a mount. Verify no errors, no dialogs, no badges appear. The app behaves exactly as before.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: complete GitHub release update checker"
+```

--- a/docs/superpowers/specs/2026-05-24-release-skill-design.md
+++ b/docs/superpowers/specs/2026-05-24-release-skill-design.md
@@ -8,7 +8,7 @@ A Claude Code skill (`/release`) that creates an OATControl release end-to-end. 
 
 - **Skill name:** `release`
 - **Location:** `.claude/skills/release.md` (project-level skill)
-- **Trigger:** User types `/release`
+- **Trigger:** User types `/release`, or uses phrases like "make a release", "let's ship", "let's release", "create a release", "ship it", "cut a release"
 
 ## Flow
 

--- a/docs/superpowers/specs/2026-05-24-release-skill-design.md
+++ b/docs/superpowers/specs/2026-05-24-release-skill-design.md
@@ -1,0 +1,83 @@
+# Release Skill Design
+
+## Overview
+
+A Claude Code skill (`/release`) that creates an OATControl release end-to-end. The skill automates version bumping, changelog generation, git operations, and GitHub draft release creation, while pausing for the manual build step that must be done in Visual Studio.
+
+## Skill Metadata
+
+- **Skill name:** `release`
+- **Location:** `.claude/skills/release.md` (project-level skill)
+- **Trigger:** User types `/release`
+
+## Flow
+
+### Step 1: Version Prompt
+
+- Read current version from `OATControl/Properties/AssemblyInfo.cs` (AssemblyVersion)
+- Show current version to user
+- Propose next version by bumping minor number (e.g. `1.2.0.0` → `1.3.0.0`)
+- User confirms or provides a different version
+- Validate new version is higher than current
+
+### Step 2: Version Bump
+
+Update version in these files:
+
+1. **`OATControl/Properties/AssemblyInfo.cs`** — Update `AssemblyVersion` and `AssemblyFileVersion` attributes
+2. **`OATControl/OATControl Setup.iss`** — Update the `AppVersion` line
+
+### Step 3: Changelog + README
+
+- Run `git log <last-tag>..HEAD --oneline` to get commits since last release tag
+- Generate bullet points from commit messages
+- Present to user for editing (both files use the same bullet text)
+- Prepend to **`OATControl/CHANGELOG.md`** — fuller descriptions with markdown formatting
+- Prepend to **`OATControl/README.txt`** — terse one-liners in existing format:
+  ```
+  OATControl V1.3.0.0                                        24 May 2026
+  - One-line change summary.
+  - Another change.
+  ```
+
+### Step 4: Commit & Tag
+
+- Stage changed files (AssemblyInfo.cs, Setup.iss, CHANGELOG.md, README.txt)
+- Commit with message: `Release V<version>`
+- Create annotated tag: `V<version>` (e.g. `V1.3.0.0`)
+
+### Step 5: Pause for Build
+
+- Tell user to build OATControl in Release mode in Visual Studio
+- Tell user to run InnoSetup to produce the installer
+- Wait for user confirmation that `OATControl\bin\SetupOutput\OATControlSetup.exe` exists
+- Verify the file exists before proceeding
+
+### Step 6: Push & Create GitHub Draft Release
+
+- Push commit and tag to remote (`git push && git push --tags`)
+- Create GitHub draft release:
+  ```
+  gh release create V<version> --draft --title "V<version>" --notes-file <temp-changelog> "OATControl/bin/SetupOutput/OATControlSetup.exe"
+  ```
+- Report the draft release URL to user
+
+## Files Modified
+
+| File | What changes |
+|------|-------------|
+| `OATControl/Properties/AssemblyInfo.cs` | AssemblyVersion, AssemblyFileVersion |
+| `OATControl/OATControl Setup.iss` | AppVersion |
+| `OATControl/CHANGELOG.md` | Prepend new version section |
+| `OATControl/README.txt` | Prepend new version block with one-liners |
+
+## Error Handling
+
+- **Pre-flight checks:** Verify `gh` CLI is available and authenticated. Verify git working tree is clean.
+- **Version validation:** New version must be higher than current.
+- **Build verification:** Check that installer .exe exists before creating release.
+- **Stop on failure:** If any step fails, report the error and stop. Do not attempt partial recovery.
+
+## Scope
+
+This skill handles **OATControl only**. ASCOM Driver and OATSimulation have separate release processes.

--- a/docs/superpowers/specs/2026-05-24-update-checker-design.md
+++ b/docs/superpowers/specs/2026-05-24-update-checker-design.md
@@ -1,0 +1,152 @@
+# GitHub Release Update Checker — Design Spec
+
+## Problem
+
+OATControl has no mechanism to notify users when a new desktop app or mount firmware version is available. Users must manually check GitHub releases.
+
+## Solution
+
+Add automatic GitHub release checking for both the desktop app and the mount firmware. Desktop checks run at startup; firmware checks run after mount connection. All network calls are fire-and-forget with short timeouts — if there's no internet (common during field imaging sessions), the app behaves exactly as it does today.
+
+## User-Facing Behavior
+
+### Desktop App Update
+
+1. On app startup, after the main window loads, an async check queries `https://api.github.com/repos/OpenAstroTech/OpenAstroTracker-Desktop/releases/latest`
+2. If a newer version is found, a modal dialog (`DlgUpdateAvailable`) appears immediately, blocking the main window
+3. The dialog shows:
+   - "OATControl V{new} is now available (you have V{current})"
+   - The release changelog (plain text from the GitHub release body)
+   - **Skip** button — dismisses the dialog, user continues normally
+   - **Upgrade** button — starts the download flow
+4. When the user clicks Upgrade:
+   - The changelog area is replaced with a progress bar
+   - The installer (~2.2 MB) is downloaded from the release asset's `browser_download_url` to the system temp folder
+   - On completion: the installer is launched via `Process.Start()` and the app exits via `Application.Current.Shutdown()`
+   - On download failure: an error message is shown; the user can close the dialog and continue normally
+5. If no update is available, or the check fails (no internet, timeout, parse error), nothing happens — no dialog, no notification
+
+### Firmware Update
+
+1. After a successful mount connection, once the firmware version has been parsed (in `MountVM.ConnectToOat`), an async check queries `https://api.github.com/repos/OpenAstroTech/OpenAstroTracker-Firmware/releases/latest`
+2. If a newer firmware version is found, two UI updates occur:
+   - A red badge indicator appears on the "Mount Settings" button in the main window
+   - In the Mount Settings dialog (SettingsDialog), below the current firmware version, clickable text appears: "new V{x.y.z} available"
+3. Clicking the firmware update text opens the GitHub release page in the default browser
+4. If the check fails (no internet, timeout, parse error), no badge or inline text appears — the UI is unchanged
+
+### Fault Tolerance
+
+- All GitHub API calls use `HttpClient` with a 5-second timeout
+- Every network call is wrapped in try/catch — failures silently return "no update available"
+- No retries, no caching, no background polling
+- The app must never block, hang, or show errors due to network issues
+
+## Architecture
+
+### New Files
+
+| File | Purpose |
+|---|---|
+| `OATControl/UpdateChecker.cs` | GitHub API queries, version parsing, comparison |
+| `OATControl/DlgUpdateAvailable.xaml` | Desktop update dialog XAML |
+| `OATControl/DlgUpdateAvailable.xaml.cs` | Dialog code-behind (changelog display, download, progress bar, launch installer) |
+
+### `UpdateChecker` class
+
+Static class with two public methods:
+
+```
+CheckForDesktopUpdateAsync() → Task<UpdateCheckResult>
+CheckForFirmwareUpdateAsync(string currentFirmwareVersion) → Task<UpdateCheckResult>
+```
+
+**`UpdateCheckResult`** is a simple data class:
+- `bool UpdateAvailable`
+- `string LatestVersion`
+- `string CurrentVersion`
+- `string Changelog` (release body markdown, displayed as plain text)
+- `string DownloadUrl` (desktop only — first asset's `browser_download_url`)
+- `string ReleasePageUrl` (`html_url` from the GitHub release)
+
+**Version parsing and comparison:**
+
+Desktop tags: `V1.2.0.0` — strip leading 'V', parse as 4-part version (`Version` class)
+Firmware tags: `v1.13.9` — strip leading 'v', parse as 3-part version (`Version` class)
+For the firmware, the app already parses the mount's firmware version into a comparable long integer. The checker should also try to parse both versions into `Version` objects and compare. If either side can't be parsed (custom build, unknown format), still attempt numeric comparison — if that also fails, return "no update".
+
+**GitHub API calls:**
+
+- Uses `HttpClient` with `User-Agent` header set (GitHub API requires it)
+- 5-second timeout
+- Deserializes JSON response to extract `tag_name`, `body`, `html_url`, and `assets[0].browser_download_url`
+- Uses `Newtonsoft.Json` (already referenced in the project, v13.0.3) for JSON deserialization
+
+### `DlgUpdateAvailable` dialog
+
+- Follows existing dialog patterns: inherits `Controls.ThemedWindow`, sets `Owner` to `Application.Current.MainWindow`, `WindowStartupLocation.CenterOwner`
+- Two display states controlled by a `IsDownloading` property:
+  - **Info state**: Shows version comparison text, changelog in a scrollable `TextBox` (read-only, word-wrap), Skip and Upgrade buttons
+  - **Download state**: Shows progress bar, download percentage text, Cancel button. Cancel aborts the download and returns to info state.
+- Download uses `HttpClient.GetAsync` with `HttpCompletionOption.ResponseHeadersRead`, reads the stream to report progress
+- Installer is saved to `Path.Combine(Path.GetTempPath(), "OATControlSetup.exe")`
+- On successful download: `Process.Start(installerPath)` then `Application.Current.Shutdown()`
+
+### Integration Points
+
+**Desktop check (startup):**
+
+In `MainWindow.xaml.cs` `OnLoaded` handler (or similar startup hook):
+```
+_ = Task.Run(() => UpdateChecker.CheckForDesktopUpdateAsync())
+    .ContinueWith(t => {
+        if (!t.IsFaulted && !t.IsCanceled && t.Result?.UpdateAvailable == true)
+            Dispatcher.Invoke(() => ShowUpdateDialog(t.Result));
+    });
+```
+
+**Firmware check (on connect):**
+
+In `MountVM.cs`, after firmware version parsing (~line 2830), set new properties:
+- `FirmwareUpdateAvailable` (bool, `INotifyPropertyChanged`)
+- `LatestFirmwareVersion` (string)
+- `LatestFirmwareReleaseUrl` (string)
+
+Call:
+```
+_ = Task.Run(() => UpdateChecker.CheckForFirmwareUpdateAsync(ScopeVersion))
+    .ContinueWith(t => {
+        if (t.Result.UpdateAvailable) {
+            FirmwareUpdateAvailable = true;
+            LatestFirmwareVersion = t.Result.LatestVersion;
+            LatestFirmwareReleaseUrl = t.Result.ReleasePageUrl;
+        }
+    }, TaskScheduler.FromCurrentSynchronizationContext());
+```
+
+### Firmware UI in SettingsDialog
+
+In `SettingsDialog.xaml`, below the firmware version `TextBlock`:
+- Add a `Hyperlink` inside a `TextBlock`, bound to `LatestFirmwareReleaseUrl`, visible only when `FirmwareUpdateAvailable` is true
+- Text: "new {LatestFirmwareVersion} available"
+- Click handler opens the URL via `Process.Start()`
+
+### Badge on Mount Settings button
+
+In `MainWindow.xaml`, the "Mount Settings" `Button`:
+- Add a small red circle badge (could be a `Border` + `TextBlock` with "!" overlaid via a `Grid` or `Canvas`)
+- Visibility bound to `FirmwareUpdateAvailable` via `BooleanToVisibilityConverter`
+
+### No Changes to OATCommunications
+
+All update-checking code lives in the OATControl project. The shared communications library is not modified.
+
+## Dependencies
+
+- `Newtonsoft.Json` (already in project, v13.0.3) — for JSON deserialization
+- `HttpClient` (available in .NET Framework 4.7.2)
+- `System.Diagnostics.Process` (for launching installer and opening browser)
+
+## Open Questions
+
+None — all clarified during brainstorming.


### PR DESCRIPTION
## Summary
- Automatic update checking for desktop app (startup) and firmware (on mount connect) via GitHub Releases API
- Update notification dialog with themed markdown changelog (MdXaml) and download with progress bar
- Firmware update badge on Mount Settings button and update link in Settings dialog
- "Skip This Version" option to suppress notifications; checks throttled to once per 24 hours
- "Check For Updates" button in App Settings General tab with inline result display
- Release skill (`/release`) for automating version bumps, changelog, tagging, and GitHub draft releases
- All network calls are fault-tolerant with 5-second timeouts — no impact when offline

## Test plan
- [ ] Start app without internet — no crash, no dialog, behaves as before
- [ ] Start app with internet — update check fires, dialog appears if newer version on GitHub
- [ ] Verify "Skip This Version" suppresses the same version on next launch
- [ ] Verify "Check For Updates" in App Settings shows inline result
- [ ] Connect to mount with internet — firmware check fires, badge appears if newer firmware
- [ ] Verify firmware badge and link work in Settings dialog
- [ ] Verify update dialog respects dark/light theme colors including headings
- [ ] Verify download progress bar works and installer launches on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)